### PR TITLE
fix(terminal-title): fix plugin description and env var docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -340,7 +340,7 @@
             "name": "terminal-title",
             "source": "./terminal-title",
             "description": "Automatically updates terminal title with emoji + project + topic context for quick visual cues when switching terminals",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "keywords": [
                 "terminal",
                 "title",

--- a/terminal-title/.claude-plugin/plugin.json
+++ b/terminal-title/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "terminal-title",
-  "description": "Automatically updates terminal title with emoji + project + topic context and establishes 2389 workflow conventions for TodoWrite task tracking",
-  "version": "1.1.0"
+  "description": "Automatically updates terminal title with emoji + project + topic context",
+  "version": "1.1.1"
 }

--- a/terminal-title/CLAUDE.md
+++ b/terminal-title/CLAUDE.md
@@ -18,7 +18,7 @@ Auto-invoked skill that:
 ## Environment Variables
 
 - `TERMINAL_TITLE_EMOJI` -- emoji prefix for the title. User sets this in their shell profile to distinguish contexts (e.g. 💼 for work, 🎉 for personal). Defaults to 🎉 if not set.
-- `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` -- set to `1` to disable automatic terminal title updates.
+- `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` -- set to `1` to disable Claude Code's *built-in* terminal title updater. Required so it doesn't conflict with this plugin.
 
 ## Title Format
 

--- a/terminal-title/skills/SKILL.md
+++ b/terminal-title/skills/SKILL.md
@@ -10,10 +10,6 @@ description: Use when session starts or conversation topic materially shifts - e
 
 Updates terminal window title to: `$TERMINAL_TITLE_EMOJI ProjectName - Topic`
 
-## Pre-flight Check
-
-If `$CLAUDE_CODE_DISABLE_TERMINAL_TITLE` is `1`, do nothing and stop.
-
 ## When to Invoke
 
 **DO invoke:**


### PR DESCRIPTION
## Summary
- Removed stale "TodoWrite task tracking" from plugin.json description
- Clarified `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` disables the built-in updater, not this plugin
- Removed incorrect pre-flight check from SKILL.md
- Bumped to 1.1.1

## Test plan
- [x] Verified terminal title still updates via Bash tool
- [x] Confirmed plugin description matches actual functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 1.1.1

* **Documentation**
  * Clarified environment variable behavior for disabling the terminal title updater
  * Removed outdated pre-flight check guidance from skill documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->