### PR TITLE
chore: bump speed-run to 1.1.1 in marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -108,7 +108,7 @@
         "url": "https://github.com/2389-research/speed-run.git"
       },
       "description": "Token-efficient code generation pipeline - parallel implementation with hosted LLM (Cerebras) for ~60% token savings. Includes MCP server.",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "keywords": [
         "codegen",
         "speed-run",


### PR DESCRIPTION
## Summary

Bumps the speed-run marketplace entry from 1.0.0 → 1.1.1 to match the standalone repo after the .mcp.json wrapper fix.

## Context

The marketplace entry for speed-run was pinned to 1.0.0 while the standalone repo at [2389-research/speed-run](https://github.com/2389-research/speed-run) had advanced to 1.1.0. With [2389-research/speed-run#2](https://github.com/2389-research/speed-run/pull/2) fixing the `.mcp.json` auto-registration bug (issue #1 on that repo), the standalone repo moves to 1.1.1.

**Merge order:**
1. First merge [2389-research/speed-run#2](https://github.com/2389-research/speed-run/pull/2) (the .mcp.json fix + version bump)
2. Then merge this PR

## Test plan

- [ ] Verify marketplace regenerates cleanly after merge
- [ ] Verify `/plugin install speed-run@2389-research` picks up the fixed .mcp.json after both PRs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 1.1.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->