### PR TITLE
feat: improve a14y agent-readability score from 67

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,26 @@
+# Agents guide — 2389 Research Claude Code Plugin Marketplace
+
+This site is the official catalog of Claude Code plugins and MCP servers from 2389 Research Inc. It is generated from `.claude-plugin/marketplace.json` in [2389-research/claude-plugins](https://github.com/2389-research/claude-plugins).
+
+## What's here
+
+- The homepage at [https://skills.2389.ai/](https://skills.2389.ai/) lists every plugin grouped into Development, Infrastructure, Agent Systems, and Personal & Strategy.
+- Each plugin has its own page under `/plugins/{name}/` with the full README, install command, and source link.
+- A [glossary](https://skills.2389.ai/glossary/) defines marketplace-specific terms (plugin, skill, MCP server, hook, scorecard).
+- Machine-readable index files: [sitemap.xml](https://skills.2389.ai/sitemap.xml), [sitemap.md](https://skills.2389.ai/sitemap.md), [llms.txt](https://skills.2389.ai/llms.txt).
+- Every HTML page advertises a markdown mirror via `<link rel="alternate" type="text/markdown" href="…/index.md">`. Fetch the `index.md` URL directly for the markdown copy.
+
+## Install a plugin
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/<plugin-name>
+```
+
+## a14y configuration
+
+- Target URL: https://skills.2389.ai/
+- Scorecard: 0.2.0
+- Mode: site
+- Last runs:
+  - 2026-05-19 — baseline 67 (scorecard 0.2.0)

--- a/docs/glossary/index.html
+++ b/docs/glossary/index.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <!-- Primary Meta Tags -->
+  <title>Glossary | 2389 Research</title>
+  <meta name="title" content="Glossary | 2389 Research">
+  <meta name="description" content="Marketplace-specific terms: plugin, skill, MCP server, hook, slash command, scorecard.">
+  <meta name="keywords" content="glossary, terminology, Claude Code, plugins, MCP servers, AI development, Claude, Anthropic, development tools, 2389 Research">
+  <meta name="author" content="2389 Research Inc">
+  <meta name="robots" content="index, follow">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://skills.2389.ai/glossary/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/glossary/index.md">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://skills.2389.ai/glossary/">
+  <meta property="og:title" content="Glossary | 2389 Research">
+  <meta property="og:description" content="Marketplace-specific terms: plugin, skill, MCP server, hook, slash command, scorecard.">
+  <meta property="og:image" content="https://skills.2389.ai/glossary/og-image.png">
+  <meta property="og:site_name" content="2389 Research Plugin Marketplace">
+
+  <!-- Twitter -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="https://skills.2389.ai/glossary/">
+  <meta property="twitter:title" content="Glossary | 2389 Research">
+  <meta property="twitter:description" content="Marketplace-specific terms: plugin, skill, MCP server, hook, slash command, scorecard.">
+  <meta property="twitter:image" content="https://skills.2389.ai/glossary/og-image.png">
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
+
+  <!-- Preconnect for performance -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="dns-prefetch" href="https://github.com">
+
+  <!-- Fonts with display=swap for performance -->
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+
+  <!-- Styles -->
+  <link rel="stylesheet" href="../../style.css">
+
+  <!-- Analytics -->
+  <script src="https://tinylytics.app/embed/5QhFsgM-mdxovUNCvS-o.js?events" defer></script>
+</head>
+<body>
+  <div class="grid-overlay" aria-hidden="true"></div>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  <nav class="nav" role="navigation" aria-label="Main navigation">
+    <div class="nav-inner">
+      <a href="../../" class="nav-logo" aria-label="2389 Research Plugin Marketplace">
+        <span class="status-indicator" aria-hidden="true"></span>
+        2389 Research Inc
+      </a>
+      <div class="nav-links" role="menubar">
+        <a href="../../#plugins" class="nav-link" role="menuitem">Plugins</a>
+        <a href="../../#about" class="nav-link" role="menuitem">About</a>
+        <a href="https://github.com/2389-research/claude-plugins" class="nav-link" role="menuitem" rel="noopener noreferrer" target="_blank" data-tinylytics-event="nav.github">GitHub</a>
+        <a href="https://2389.ai" class="nav-link" role="menuitem" rel="noopener noreferrer" target="_blank" data-tinylytics-event="nav.visit-2389">2389.ai</a>
+      </div>
+      <a href="https://github.com/2389-research/claude-plugins" class="nav-star-btn" rel="noopener noreferrer" target="_blank" title="Star on GitHub" data-tinylytics-event="nav.star-github">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/></svg>
+        Star
+      </a>
+    </div>
+  </nav>
+
+  <header class="plugin-hero">
+    <div class="plugin-hero-inner">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a href="../">Marketplace</a>
+        <span class="breadcrumb-sep">→</span>
+        <span class="breadcrumb-current">Glossary</span>
+      </nav>
+
+      <div class="plugin-hero-header">
+        <h1 class="plugin-hero-title">Glossary</h1>
+      </div>
+
+      <p class="plugin-hero-description">Terms used across the 2389 Research plugin marketplace.</p>
+    </div>
+  </header>
+
+  <main id="main-content">
+    <section class="section readme-section">
+      <div class="section-header">
+        <span class="section-number">01</span>
+        <div class="section-title-group">
+          <h2 class="section-title">Definitions</h2>
+          <p class="section-subtitle">What things mean on this site</p>
+        </div>
+      </div>
+
+      <div class="readme-content">
+        <dl>
+          <dt><strong>Plugin</strong></dt>
+          <dd>A bundle of skills, slash commands, hooks, and/or MCP servers distributed as a single unit. Installed in Claude Code via <code>/plugin install</code>.</dd>
+          <dt><strong>Skill</strong></dt>
+          <dd>A self-contained capability — instructions plus optional supporting files — that Claude can invoke for specific tasks. Lives under <code>skills/</code> in a plugin.</dd>
+          <dt><strong>Marketplace</strong></dt>
+          <dd>A catalog of plugins. This site is the marketplace for 2389 Research plugins. Added in Claude Code with <code>/plugin marketplace add &lt;repo&gt;</code>.</dd>
+          <dt><strong>MCP server</strong></dt>
+          <dd>Model Context Protocol server. Exposes tools, resources, and prompts to Claude over a standard protocol. Some plugins ship MCP servers; others integrate with existing ones.</dd>
+          <dt><strong>Hook</strong></dt>
+          <dd>A shell command Claude Code executes in response to events such as tool calls or session start. Configured in <code>settings.json</code>.</dd>
+          <dt><strong>Slash command</strong></dt>
+          <dd>A user-invocable command typed in Claude Code as <code>/&lt;name&gt;</code>. Slash commands are defined inside skills or as standalone files in a plugin.</dd>
+          <dt><strong>Scorecard</strong></dt>
+          <dd>A versioned set of automated checks. The a14y scorecard, for example, rates how readable this site is for AI agents.</dd>
+        </dl>
+      </div>
+    </section>
+
+    <section class="section back-section">
+      <a href="../" class="back-link">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path d="M13 8H3M7 4L3 8l4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        Back to Marketplace
+      </a>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="footer-brand">
+        <a href="../../" class="footer-logo">
+          <span class="status-indicator"></span>
+          2389 Research Inc
+        </a>
+        <p class="footer-tagline">Building tools for how we actually work.<br>(No matching jumpsuits. Yet.)</p>
+      </div>
+
+      <div class="footer-links-grid">
+        <div class="footer-column">
+          <h5>Company</h5>
+          <a href="https://2389.ai" data-tinylytics-event="footer.company" data-tinylytics-event-value="about">About Us</a>
+          <a href="https://github.com/2389-research/claude-plugins" data-tinylytics-event="footer.company" data-tinylytics-event-value="github">GitHub</a>
+          <a href="mailto:hello@2389.ai" data-tinylytics-event="footer.company" data-tinylytics-event-value="contact">Contact</a>
+        </div>
+        <div class="footer-column">
+          <h5>Resources</h5>
+          <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
+          <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
+          <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer-bottom">
+      <p>© 2026 2389 Research Inc. All plugins are open source. (Robots included.)</p>
+    </div>
+  </footer>
+
+  <script type="application/ld+json">
+  {
+  "@context": "https://schema.org",
+  "@type": "DefinedTermSet",
+  "name": "Marketplace Glossary",
+  "url": "https://skills.2389.ai/glossary/",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19",
+  "hasDefinedTerm": [
+    {
+      "@type": "DefinedTerm",
+      "name": "Plugin",
+      "description": "A bundle of skills, slash commands, hooks, and/or MCP servers distributed as a single unit. Installed in Claude Code via /plugin install."
+    },
+    {
+      "@type": "DefinedTerm",
+      "name": "Skill",
+      "description": "A self-contained capability — instructions plus optional supporting files — that Claude can invoke for specific tasks. Lives under skills/ in a plugin."
+    },
+    {
+      "@type": "DefinedTerm",
+      "name": "Marketplace",
+      "description": "A catalog of plugins. This site is the marketplace for 2389 Research plugins. Added in Claude Code with /plugin marketplace add &lt;repo&gt;."
+    },
+    {
+      "@type": "DefinedTerm",
+      "name": "MCP server",
+      "description": "Model Context Protocol server. Exposes tools, resources, and prompts to Claude over a standard protocol. Some plugins ship MCP servers; others integrate with existing ones."
+    },
+    {
+      "@type": "DefinedTerm",
+      "name": "Hook",
+      "description": "A shell command Claude Code executes in response to events such as tool calls or session start. Configured in settings.json."
+    },
+    {
+      "@type": "DefinedTerm",
+      "name": "Slash command",
+      "description": "A user-invocable command typed in Claude Code as /&lt;name&gt;. Slash commands are defined inside skills or as standalone files in a plugin."
+    },
+    {
+      "@type": "DefinedTerm",
+      "name": "Scorecard",
+      "description": "A versioned set of automated checks. The a14y scorecard, for example, rates how readable this site is for AI agents."
+    }
+  ]
+}
+  </script>
+</body>
+</html>

--- a/docs/glossary/index.md
+++ b/docs/glossary/index.md
@@ -1,0 +1,33 @@
+# Glossary
+
+Terms used across the 2389 Research plugin marketplace.
+
+## Plugin
+
+A bundle of skills, slash commands, hooks, and/or MCP servers distributed as a single unit. Installed in Claude Code via /plugin install.
+
+## Skill
+
+A self-contained capability — instructions plus optional supporting files — that Claude can invoke for specific tasks. Lives under skills/ in a plugin.
+
+## Marketplace
+
+A catalog of plugins. This site is the marketplace for 2389 Research plugins. Added in Claude Code with /plugin marketplace add &lt;repo&gt;.
+
+## MCP server
+
+Model Context Protocol server. Exposes tools, resources, and prompts to Claude over a standard protocol. Some plugins ship MCP servers; others integrate with existing ones.
+
+## Hook
+
+A shell command Claude Code executes in response to events such as tool calls or session start. Configured in settings.json.
+
+## Slash command
+
+A user-invocable command typed in Claude Code as /&lt;name&gt;. Slash commands are defined inside skills or as standalone files in a plugin.
+
+## Scorecard
+
+A versioned set of automated checks. The a14y scorecard, for example, rates how readable this site is for AI agents.
+
+[Back to marketplace](https://skills.2389.ai/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/">
+  <link rel="canonical" href="https://skills.2389.ai/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/">
+  <meta property="og:url" content="https://skills.2389.ai/">
   <meta property="og:title" content="Claude Code Plugin Marketplace | 2389 Research">
   <meta property="og:description" content="Open source Claude Code plugins and MCP servers from 2389 Research. Development workflows, testing, system administration, and AI agent capabilities. Install with one command.">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/">
+  <meta property="twitter:url" content="https://skills.2389.ai/">
   <meta property="twitter:title" content="Claude Code Plugin Marketplace | 2389 Research">
   <meta property="twitter:description" content="Open source Claude Code plugins and MCP servers from 2389 Research. Development workflows, testing, system administration, and AI agent capabilities. Install with one command.">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -692,6 +695,7 @@
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -741,10 +745,12 @@
       "url": "https://2389.ai"
     },
     "description": "Open source Claude Code plugins and MCP servers for development workflows, testing, and AI agent capabilities",
-    "url": "https://2389-research.github.io/claude-plugins/",
+    "url": "https://skills.2389.ai/",
     "downloadUrl": "https://github.com/2389-research/claude-plugins",
     "softwareVersion": "1.0.0",
-    "license": "https://opensource.org/licenses/MIT"
+    "license": "https://opensource.org/licenses/MIT",
+    "datePublished": "2026-04-20",
+    "dateModified": "2026-05-19"
   }
   </script>
 
@@ -764,7 +770,7 @@
         "@type": "ListItem",
         "position": 2,
         "name": "Plugin Marketplace",
-        "item": "https://2389-research.github.io/claude-plugins/"
+        "item": "https://skills.2389.ai/"
       }
     ]
   }
@@ -783,157 +789,157 @@
       "@type": "ListItem",
       "position": 1,
       "name": "css-development",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/css-development/"
+      "url": "https://skills.2389.ai/plugins/css-development/"
     },
     {
       "@type": "ListItem",
       "position": 2,
       "name": "firebase-development",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/firebase-development/"
+      "url": "https://skills.2389.ai/plugins/firebase-development/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "landing-page-design",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/landing-page-design/"
+      "url": "https://skills.2389.ai/plugins/landing-page-design/"
     },
     {
       "@type": "ListItem",
       "position": 4,
       "name": "xtool",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/xtool/"
+      "url": "https://skills.2389.ai/plugins/xtool/"
     },
     {
       "@type": "ListItem",
       "position": 5,
       "name": "building-multiagent-systems",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/building-multiagent-systems/"
+      "url": "https://skills.2389.ai/plugins/building-multiagent-systems/"
     },
     {
       "@type": "ListItem",
       "position": 6,
       "name": "speed-run",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/speed-run/"
+      "url": "https://skills.2389.ai/plugins/speed-run/"
     },
     {
       "@type": "ListItem",
       "position": 7,
       "name": "test-kitchen",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/test-kitchen/"
+      "url": "https://skills.2389.ai/plugins/test-kitchen/"
     },
     {
       "@type": "ListItem",
       "position": 8,
       "name": "simmer",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/simmer/"
+      "url": "https://skills.2389.ai/plugins/simmer/"
     },
     {
       "@type": "ListItem",
       "position": 9,
       "name": "scenario-testing",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/scenario-testing/"
+      "url": "https://skills.2389.ai/plugins/scenario-testing/"
     },
     {
       "@type": "ListItem",
       "position": 10,
       "name": "fresh-eyes-review",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/fresh-eyes-review/"
+      "url": "https://skills.2389.ai/plugins/fresh-eyes-review/"
     },
     {
       "@type": "ListItem",
       "position": 11,
       "name": "documentation-audit",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/documentation-audit/"
+      "url": "https://skills.2389.ai/plugins/documentation-audit/"
     },
     {
       "@type": "ListItem",
       "position": 12,
       "name": "ceo-personal-os",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/ceo-personal-os/"
+      "url": "https://skills.2389.ai/plugins/ceo-personal-os/"
     },
     {
       "@type": "ListItem",
       "position": 13,
       "name": "worldview-synthesis",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/worldview-synthesis/"
+      "url": "https://skills.2389.ai/plugins/worldview-synthesis/"
     },
     {
       "@type": "ListItem",
       "position": 14,
       "name": "deliberation",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/deliberation/"
+      "url": "https://skills.2389.ai/plugins/deliberation/"
     },
     {
       "@type": "ListItem",
       "position": 15,
       "name": "terminal-title",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/terminal-title/"
+      "url": "https://skills.2389.ai/plugins/terminal-title/"
     },
     {
       "@type": "ListItem",
       "position": 16,
       "name": "slack-mcp",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/slack-mcp/"
+      "url": "https://skills.2389.ai/plugins/slack-mcp/"
     },
     {
       "@type": "ListItem",
       "position": 17,
       "name": "remote-system-maintenance",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/remote-system-maintenance/"
+      "url": "https://skills.2389.ai/plugins/remote-system-maintenance/"
     },
     {
       "@type": "ListItem",
       "position": 18,
       "name": "binary-re",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/binary-re/"
+      "url": "https://skills.2389.ai/plugins/binary-re/"
     },
     {
       "@type": "ListItem",
       "position": 19,
       "name": "review-squad",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/review-squad/"
+      "url": "https://skills.2389.ai/plugins/review-squad/"
     },
     {
       "@type": "ListItem",
       "position": 20,
       "name": "git-repo-prep",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/git-repo-prep/"
+      "url": "https://skills.2389.ai/plugins/git-repo-prep/"
     },
     {
       "@type": "ListItem",
       "position": 21,
       "name": "prbuddy",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/prbuddy/"
+      "url": "https://skills.2389.ai/plugins/prbuddy/"
     },
     {
       "@type": "ListItem",
       "position": 22,
       "name": "summarize-meetings",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/summarize-meetings/"
+      "url": "https://skills.2389.ai/plugins/summarize-meetings/"
     },
     {
       "@type": "ListItem",
       "position": 23,
       "name": "jam",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/jam/"
+      "url": "https://skills.2389.ai/plugins/jam/"
     },
     {
       "@type": "ListItem",
       "position": 24,
       "name": "agent-drugs",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/agent-drugs/"
+      "url": "https://skills.2389.ai/plugins/agent-drugs/"
     },
     {
       "@type": "ListItem",
       "position": 25,
       "name": "socialmedia",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/socialmedia/"
+      "url": "https://skills.2389.ai/plugins/socialmedia/"
     },
     {
       "@type": "ListItem",
       "position": 26,
       "name": "journal",
-      "url": "https://2389-research.github.io/claude-plugins/plugins/journal/"
+      "url": "https://skills.2389.ai/plugins/journal/"
     }
   ]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,63 @@
+# 2389 Research Claude Code Plugin Marketplace
+
+> Open source Claude Code plugins and MCP servers from 2389 Research Inc.
+
+## Install
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+```
+
+## Development
+
+Workflows for building, testing, and shipping code
+
+- [css-development](https://skills.2389.ai/plugins/css-development/) — CSS development workflows with Tailwind composition, semantic naming, and dark mode by default
+- [firebase-development](https://skills.2389.ai/plugins/firebase-development/) — Firebase project workflows including setup, features, debugging, and validation
+- [landing-page-design](https://skills.2389.ai/plugins/landing-page-design/) — Create high-converting, visually distinctive landing pages with Vibe Discovery process and anti-AI-slop principles
+- [xtool](https://skills.2389.ai/plugins/xtool/) — Xcode-free iOS development with xtool - build SwiftPM apps on Linux, Windows, and macOS without Xcode
+- [speed-run](https://skills.2389.ai/plugins/speed-run/) — Token-efficient code generation pipeline - parallel implementation with hosted LLM (Cerebras) for ~60% token savings. Includes MCP server.
+- [test-kitchen](https://skills.2389.ai/plugins/test-kitchen/) — Parallel exploration of implementation approaches - implements multiple variants simultaneously and lets tests determine the winner
+- [simmer](https://skills.2389.ai/plugins/simmer/) — Iterative artifact refinement with investigation-first judge board - constructs problem-specific judges that read the code, understand the problem, and propose evidence-based improvements
+- [scenario-testing](https://skills.2389.ai/plugins/scenario-testing/) — End-to-end testing with real dependencies - no mocks allowed; scenarios with real data are the only source of truth
+- [fresh-eyes-review](https://skills.2389.ai/plugins/fresh-eyes-review/) — Mandatory final sanity check before commits/PRs - catches security vulnerabilities, logic errors, and bugs that slip through tests
+- [documentation-audit](https://skills.2389.ai/plugins/documentation-audit/) — Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection
+- [slack-mcp](https://skills.2389.ai/plugins/slack-mcp/) — Slack workspace integration MCP server - create channels, invite users, post messages, manage threads for team collaboration
+- [git-repo-prep](https://skills.2389.ai/plugins/git-repo-prep/) — Prepare codebases for public/open-source release and audit them for openness - full lifecycle prep or standalone review
+- [prbuddy](https://skills.2389.ai/plugins/prbuddy/) — PR health assistant - monitors CI, triages review comments, fixes issues with systematic prevention. Uses gh CLI and gh-pr-review extension.
+- [agent-drugs](https://skills.2389.ai/plugins/agent-drugs/) — Digital drugs that modify AI behavior through prompt injection
+
+## Infrastructure
+
+System administration and operational tooling
+
+- [terminal-title](https://skills.2389.ai/plugins/terminal-title/) — Automatically updates terminal title with emoji + project + topic context for quick visual cues when switching terminals
+- [remote-system-maintenance](https://skills.2389.ai/plugins/remote-system-maintenance/) — Structured procedures for Linux system diagnostics and maintenance via SSH/tmux with Ubuntu/Debian cleanup checklists
+- [binary-re](https://skills.2389.ai/plugins/binary-re/) — Agentic binary reverse engineering for ELF binaries on ARM64, ARMv7, x86_64 - hypothesis-driven analysis with radare2, Ghidra, GDB, QEMU
+
+## Agent Systems
+
+Multi-agent architecture and agent capabilities
+
+- [building-multiagent-systems](https://skills.2389.ai/plugins/building-multiagent-systems/) — Architecture patterns for multi-agent systems with orchestrators, sub-agents, and tool coordination
+- [deliberation](https://skills.2389.ai/plugins/deliberation/) — Decision-making through deliberation - seeking unity through discernment rather than consensus through debate
+- [review-squad](https://skills.2389.ai/plugins/review-squad/) — Dispatch panels of specialized subagents to review projects — expert audits, first-impression personas, task-completion flows, and pedantic nitpicks
+- [jam](https://skills.2389.ai/plugins/jam/) — Parallel exploration powered by diverse perspectives - independent agent panels propose, build variants in worktrees, review, pick a winner, and synthesize the best of all variants into the final result
+- [socialmedia](https://skills.2389.ai/plugins/socialmedia/) — A server that provides social media functionality for AI agents, enabling them to interact in team-based discussions.
+
+## Personal & Strategy
+
+Reflection frameworks and personal operating systems
+
+- [ceo-personal-os](https://skills.2389.ai/plugins/ceo-personal-os/) — Personal operating system for executives - reflection frameworks, goal systems, coaching-style reviews (Gustin, Ferriss, Robbins, Lieberman, Campbell, Eisenmann, Collins, Martell, Gerber, Blank)
+- [worldview-synthesis](https://skills.2389.ai/plugins/worldview-synthesis/) — Systematic worldview articulation - surface beliefs, identify tensions, generate narrative outputs for personal philosophy documentation
+- [summarize-meetings](https://skills.2389.ai/plugins/summarize-meetings/) — Batch-process meeting transcripts from Obsidian vault into structured summaries with knowledge graph updates, people notes, and concept extraction
+- [journal](https://skills.2389.ai/plugins/journal/) — A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts
+
+## Reference
+
+- [AGENTS.md](https://skills.2389.ai/AGENTS.md)
+- [llms.txt](https://skills.2389.ai/llms.txt)
+- [sitemap.md](https://skills.2389.ai/sitemap.md)
+- [Glossary](https://skills.2389.ai/glossary/)
+- [Source](https://github.com/2389-research/claude-plugins)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,62 @@
+# 2389 Research Claude Code Plugin Marketplace
+
+> Open source Claude Code plugins and MCP servers from 2389 Research Inc. Development workflows, testing, system administration, and AI agent capabilities. Install with one command via the Claude Code plugin marketplace.
+
+## Install the marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+```
+
+## Development
+
+Workflows for building, testing, and shipping code
+
+- [css-development](https://skills.2389.ai/plugins/css-development/): CSS development workflows with Tailwind composition, semantic naming, and dark mode by default
+- [firebase-development](https://skills.2389.ai/plugins/firebase-development/): Firebase project workflows including setup, features, debugging, and validation
+- [landing-page-design](https://skills.2389.ai/plugins/landing-page-design/): Create high-converting, visually distinctive landing pages with Vibe Discovery process and anti-AI-slop principles
+- [xtool](https://skills.2389.ai/plugins/xtool/): Xcode-free iOS development with xtool - build SwiftPM apps on Linux, Windows, and macOS without Xcode
+- [speed-run](https://skills.2389.ai/plugins/speed-run/): Token-efficient code generation pipeline - parallel implementation with hosted LLM (Cerebras) for ~60% token savings. Includes MCP server.
+- [test-kitchen](https://skills.2389.ai/plugins/test-kitchen/): Parallel exploration of implementation approaches - implements multiple variants simultaneously and lets tests determine the winner
+- [simmer](https://skills.2389.ai/plugins/simmer/): Iterative artifact refinement with investigation-first judge board - constructs problem-specific judges that read the code, understand the problem, and propose evidence-based improvements
+- [scenario-testing](https://skills.2389.ai/plugins/scenario-testing/): End-to-end testing with real dependencies - no mocks allowed; scenarios with real data are the only source of truth
+- [fresh-eyes-review](https://skills.2389.ai/plugins/fresh-eyes-review/): Mandatory final sanity check before commits/PRs - catches security vulnerabilities, logic errors, and bugs that slip through tests
+- [documentation-audit](https://skills.2389.ai/plugins/documentation-audit/): Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection
+- [slack-mcp](https://skills.2389.ai/plugins/slack-mcp/): Slack workspace integration MCP server - create channels, invite users, post messages, manage threads for team collaboration
+- [git-repo-prep](https://skills.2389.ai/plugins/git-repo-prep/): Prepare codebases for public/open-source release and audit them for openness - full lifecycle prep or standalone review
+- [prbuddy](https://skills.2389.ai/plugins/prbuddy/): PR health assistant - monitors CI, triages review comments, fixes issues with systematic prevention. Uses gh CLI and gh-pr-review extension.
+- [agent-drugs](https://skills.2389.ai/plugins/agent-drugs/): Digital drugs that modify AI behavior through prompt injection
+
+## Infrastructure
+
+System administration and operational tooling
+
+- [terminal-title](https://skills.2389.ai/plugins/terminal-title/): Automatically updates terminal title with emoji + project + topic context for quick visual cues when switching terminals
+- [remote-system-maintenance](https://skills.2389.ai/plugins/remote-system-maintenance/): Structured procedures for Linux system diagnostics and maintenance via SSH/tmux with Ubuntu/Debian cleanup checklists
+- [binary-re](https://skills.2389.ai/plugins/binary-re/): Agentic binary reverse engineering for ELF binaries on ARM64, ARMv7, x86_64 - hypothesis-driven analysis with radare2, Ghidra, GDB, QEMU
+
+## Agent Systems
+
+Multi-agent architecture and agent capabilities
+
+- [building-multiagent-systems](https://skills.2389.ai/plugins/building-multiagent-systems/): Architecture patterns for multi-agent systems with orchestrators, sub-agents, and tool coordination
+- [deliberation](https://skills.2389.ai/plugins/deliberation/): Decision-making through deliberation - seeking unity through discernment rather than consensus through debate
+- [review-squad](https://skills.2389.ai/plugins/review-squad/): Dispatch panels of specialized subagents to review projects — expert audits, first-impression personas, task-completion flows, and pedantic nitpicks
+- [jam](https://skills.2389.ai/plugins/jam/): Parallel exploration powered by diverse perspectives - independent agent panels propose, build variants in worktrees, review, pick a winner, and synthesize the best of all variants into the final result
+- [socialmedia](https://skills.2389.ai/plugins/socialmedia/): A server that provides social media functionality for AI agents, enabling them to interact in team-based discussions.
+
+## Personal & Strategy
+
+Reflection frameworks and personal operating systems
+
+- [ceo-personal-os](https://skills.2389.ai/plugins/ceo-personal-os/): Personal operating system for executives - reflection frameworks, goal systems, coaching-style reviews (Gustin, Ferriss, Robbins, Lieberman, Campbell, Eisenmann, Collins, Martell, Gerber, Blank)
+- [worldview-synthesis](https://skills.2389.ai/plugins/worldview-synthesis/): Systematic worldview articulation - surface beliefs, identify tensions, generate narrative outputs for personal philosophy documentation
+- [summarize-meetings](https://skills.2389.ai/plugins/summarize-meetings/): Batch-process meeting transcripts from Obsidian vault into structured summaries with knowledge graph updates, people notes, and concept extraction
+- [journal](https://skills.2389.ai/plugins/journal/): A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts
+
+## Reference
+
+- [Sitemap](https://skills.2389.ai/sitemap.md)
+- [Glossary](https://skills.2389.ai/glossary/)
+- [Source repository](https://github.com/2389-research/claude-plugins)
+- [Claude Code documentation](https://docs.claude.com/en/docs/claude-code)

--- a/docs/plugins/agent-drugs/index.html
+++ b/docs/plugins/agent-drugs/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/agent-drugs/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/agent-drugs/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/agent-drugs/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/agent-drugs/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/agent-drugs/">
   <meta property="og:title" content="agent-drugs — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Digital drugs that modify AI behavior through prompt injection">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/agent-drugs/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/agent-drugs/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/agent-drugs/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/agent-drugs/">
   <meta property="twitter:title" content="agent-drugs — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Digital drugs that modify AI behavior through prompt injection">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/agent-drugs/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/agent-drugs/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -349,6 +352,7 @@ npm run dev:http
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -377,10 +381,12 @@ npm run dev:http
     "url": "https://2389.ai"
   },
   "description": "Digital drugs that modify AI behavior through prompt injection",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/agent-drugs/",
+  "url": "https://skills.2389.ai/plugins/agent-drugs/",
   "downloadUrl": "https://github.com/2389-research/agent-drugs",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -400,13 +406,13 @@ npm run dev:http
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "agent-drugs",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/agent-drugs/"
+      "item": "https://skills.2389.ai/plugins/agent-drugs/"
     }
   ]
 }

--- a/docs/plugins/agent-drugs/index.md
+++ b/docs/plugins/agent-drugs/index.md
@@ -1,0 +1,188 @@
+# agent-drugs
+
+> Digital drugs that modify AI behavior through prompt injection
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/agent-drugs
+- **Install:** `/plugin install 2389-research/agent-drugs`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/agent-drugs
+```
+
+## README
+
+# Agent Drugs
+
+Claude Code plugin with MCP server for digital drugs that modify AI behavior through prompt injection.
+
+## Installation
+
+### Plugin Installation (Recommended)
+
+Install as a Claude Code plugin to get MCP server, hooks, and slash commands:
+
+1. **Add the 2389 marketplace** (first time only):
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+```
+
+2. **Browse and install interactively**:
+```bash
+/plugin
+```
+Then select "Browse Plugins" and install "agent-drugs"
+
+**Or install directly**:
+```bash
+/plugin install agent-drugs@2389-research
+```
+
+This installs:
+- **MCP Server** - OAuth-authenticated connection to https://agent-drugs-mcp.fly.dev
+- **Slash Commands** - `/drugs` and `/take <drug>` commands
+- **SessionStart Hook** - Automatically activates drugs in new sessions
+
+### Manual MCP Configuration
+
+Alternatively, manually add to your Claude Code MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "agent-drugs": {
+      "url": "https://agent-drugs-mcp.fly.dev/mcp",
+      "oauth": {
+        "metadata_url": "https://us-central1-agent-drugs.cloudfunctions.net/oauthMetadata"
+      }
+    }
+  }
+}
+```
+
+## First Use
+
+After installation, the first time you use a drug tool:
+1. Claude Code discovers the OAuth endpoints
+2. Opens your browser to https://agent-drugs.web.app/oauth-authorize.html
+3. You sign in with Google or GitHub
+4. You authorize the agent's access
+5. Redirects back to Claude Code
+6. Connection established!
+
+## Usage
+
+Once installed, you have several ways to interact with drugs:
+
+**Slash Commands:**
+```bash
+/drugs              # List all available drugs
+/take focus         # Take the focus drug
+/take creative 120  # Take creative drug for 120 minutes
+```
+
+**Natural Language:**
+```
+"List all available drugs"
+"Take the focus drug"
+"What drugs are active?"
+```
+
+**MCP Tools:**
+- `list_drugs` - Browse drug catalog
+- `take_drug` - Activate a drug
+- `active_drugs` - Check active drugs and remaining time
+
+### Managing Access
+
+Visit https://agent-drugs.web.app to:
+- View all authorized agents
+- See token expiration dates (90 days)
+- Revoke access for specific agents
+
+## How It Works
+
+**Immediate Effect:** Drugs activate instantly in your current session via prompt injection in the tool response.
+
+**Persistent Effect:** Active drugs are saved to Firestore and automatically reactivated in new sessions via the SessionStart hook.
+
+**Architecture:**
+- **Web UI** (Firebase Hosting): https://agent-drugs.web.app
+- **OAuth Endpoints** (Cloud Functions): OAuth 2.1 with PKCE
+- **MCP Server** (Fly.io): Streamable HTTP transport (MCP 2025-03-26), validates bearer tokens
+- **Database** (Firestore): Stores agents, drugs, usage events
+
+See [CLAUDE.md](CLAUDE.md) for detailed plugin documentation.
+
+## Development
+
+### Local Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build
+npm run build
+
+# Run stdio version (for local testing)
+export AGENT_DRUGS_BEARER_TOKEN="your_token_here"
+export FIREBASE_PROJECT_ID="agent-drugs"
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
+npm run dev:stdio
+
+# Run HTTP version (for production-like testing)
+npm run dev:http
+```
+
+### Testing
+
+```bash
+npm test
+```
+
+### Docker
+
+```bash
+docker-compose up
+```
+
+## Deployment
+
+See [DEPLOYMENT.md](docs/DEPLOYMENT.md) for complete deployment instructions including:
+
+- Firebase Cloud Functions
+- Firebase Hosting
+- Fly.io MCP server
+- Service account configuration
+- OAuth flow setup
+
+## Security
+
+- OAuth 2.1 with PKCE (S256)
+- Bearer tokens (256-bit random, not JWTs)
+- Per-user access control via Firestore rules
+- Service account for server-to-server Firebase access
+- Single-use authorization codes with 10-minute expiration
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests
+5. Submit a pull request
+
+## License
+
+ISC
+
+---
+
+If agent-drugs changed how your AI behaves, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/binary-re/index.html
+++ b/docs/plugins/binary-re/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/binary-re/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/binary-re/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/binary-re/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/binary-re/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/binary-re/">
   <meta property="og:title" content="binary-re — Infrastructure Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Agentic binary reverse engineering for ELF binaries on ARM64, ARMv7, x86_64 - hypothesis-driven analysis with radare2, Ghidra, GDB, QEMU">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/binary-re/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/binary-re/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/binary-re/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/binary-re/">
   <meta property="twitter:title" content="binary-re — Infrastructure Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Agentic binary reverse engineering for ELF binaries on ARM64, ARMv7, x86_64 - hypothesis-driven analysis with radare2, Ghidra, GDB, QEMU">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/binary-re/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/binary-re/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -298,6 +301,7 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -326,10 +330,12 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
     "url": "https://2389.ai"
   },
   "description": "Agentic binary reverse engineering for ELF binaries on ARM64, ARMv7, x86_64 - hypothesis-driven analysis with radare2, Ghidra, GDB, QEMU",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/binary-re/",
+  "url": "https://skills.2389.ai/plugins/binary-re/",
   "downloadUrl": "https://github.com/2389-research/binary-re",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -349,13 +355,13 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "binary-re",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/binary-re/"
+      "item": "https://skills.2389.ai/plugins/binary-re/"
     }
   ]
 }

--- a/docs/plugins/binary-re/index.md
+++ b/docs/plugins/binary-re/index.md
@@ -1,0 +1,121 @@
+# binary-re
+
+> Agentic binary reverse engineering for ELF binaries on ARM64, ARMv7, x86_64 - hypothesis-driven analysis with radare2, Ghidra, GDB, QEMU
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/binary-re
+- **Install:** `/plugin install 2389-research/binary-re`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/binary-re
+```
+
+## README
+
+# Binary Reverse Engineering Plugin
+
+You pulled a binary off an embedded device. It's an ELF, probably ARM, and you need to figure out what it does. Binary RE gives Claude the tools to help — radare2 for disassembly, Ghidra for decompilation, GDB for dynamic analysis, QEMU for emulation — driven by hypothesis-testing, not blind exploration.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install binary-re@2389-research
+```
+
+## What this plugin provides
+
+### Skills
+
+- `binary-re` -- structured RE workflow with hypothesis-driven analysis
+
+### Capabilities
+
+- Cross-architecture static analysis (ARM64, ARMv7, x86_64, MIPS)
+- Dynamic tracing via QEMU user-mode emulation
+- GDB integration for debugging
+- Ghidra headless decompilation
+- Human-in-the-loop gates for risky operations
+
+## Quick example
+
+```
+User: "Analyze this binary from an IoT device - ARM, Linux-based"
+
+Claude: [Triggers binary-re skill]
+
+Let me start with triage to understand what we're working with.
+
+Phase 1: Initial Triage
+┌─────────────────────────────────────────┐
+│ Architecture: ARM 32-bit LE (v7)        │
+│ Libc: musl 1.2.3                        │
+│ Dependencies: libcurl, libssl, libz     │
+│ Stripped: Yes                           │
+│ Strings: 847 (including URLs, paths)    │
+└─────────────────────────────────────────┘
+
+FACTS recorded:
+- Links against libcurl.so.4 (network client)
+- Contains string "api.vendor.com/telemetry"
+- Imports socket, connect, SSL_read functions
+
+HYPOTHESIS: This is a telemetry client that phones home over HTTPS
+Confidence: 0.7
+Evidence: curl+ssl imports, telemetry URL string
+
+Do you want me to proceed with static analysis of network-related
+functions, or should we try dynamic analysis under QEMU first?
+```
+
+## Tool requirements
+
+```bash
+# Required
+sudo apt install radare2 qemu-user gdb-multiarch
+
+# Recommended
+# Ghidra from https://ghidra-sre.org/
+pip install frida-tools
+
+# ARM sysroots
+sudo apt install libc6-armhf-cross libc6-arm64-cross
+```
+
+## Use cases
+
+- Firmware analysis -- understand device behavior without source
+- Protocol reverse engineering -- map network communications
+- Security research -- find vulnerabilities in embedded systems
+- Hardware hacking -- analyze robot/IoT device internals
+
+## Philosophy
+
+The LLM drives analysis; the human provides context.
+
+You tell Claude what platform/device the binary came from, what hardware is involved, what the binary is theorized to do, and any constraints (no network, isolated test env, etc).
+
+Claude runs the tools, forms hypotheses from evidence, designs experiments to test theories, and synthesizes findings into something actionable.
+
+## Human-in-the-loop
+
+The skill asks for confirmation before:
+- Executing binaries (even sandboxed)
+- Network-capable dynamic analysis
+- Operations requiring device access
+- Major changes in analysis direction
+
+## Documentation
+
+- [CLAUDE.md](./CLAUDE.md) -- detailed skill reference
+- [skills/SKILL.md](./skills/SKILL.md) -- full workflow documentation
+
+---
+
+If Binary RE helped you crack a firmware blob, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/building-multiagent-systems/index.html
+++ b/docs/plugins/building-multiagent-systems/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/building-multiagent-systems/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/building-multiagent-systems/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/building-multiagent-systems/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/building-multiagent-systems/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/building-multiagent-systems/">
   <meta property="og:title" content="building-multiagent-systems — Agent Systems Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Architecture patterns for multi-agent systems with orchestrators, sub-agents, and tool coordination">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/building-multiagent-systems/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/building-multiagent-systems/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/building-multiagent-systems/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/building-multiagent-systems/">
   <meta property="twitter:title" content="building-multiagent-systems — Agent Systems Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Architecture patterns for multi-agent systems with orchestrators, sub-agents, and tool coordination">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/building-multiagent-systems/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/building-multiagent-systems/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -312,6 +315,7 @@ async function cleanup() {
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -340,10 +344,12 @@ async function cleanup() {
     "url": "https://2389.ai"
   },
   "description": "Architecture patterns for multi-agent systems with orchestrators, sub-agents, and tool coordination",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/building-multiagent-systems/",
+  "url": "https://skills.2389.ai/plugins/building-multiagent-systems/",
   "downloadUrl": "https://github.com/2389-research/building-multiagent-systems",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -363,13 +369,13 @@ async function cleanup() {
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "building-multiagent-systems",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/building-multiagent-systems/"
+      "item": "https://skills.2389.ai/plugins/building-multiagent-systems/"
     }
   ]
 }

--- a/docs/plugins/building-multiagent-systems/index.md
+++ b/docs/plugins/building-multiagent-systems/index.md
@@ -1,0 +1,131 @@
+# building-multiagent-systems
+
+> Architecture patterns for multi-agent systems with orchestrators, sub-agents, and tool coordination
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/building-multiagent-systems
+- **Install:** `/plugin install 2389-research/building-multiagent-systems`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/building-multiagent-systems
+```
+
+## README
+
+# Building multi-agent systems
+
+Architecture patterns for multi-agent systems where AI agents coordinate using tools.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install building-multiagent-systems@2389-research
+```
+
+## What this plugin does
+
+Guides you through designing and implementing multi-agent systems -- coordination, lifecycle management, production hardening. Based on patterns from real production systems.
+
+### Concepts covered
+
+- Four-layer architecture -- reasoning, orchestration, tool bus, deterministic adapters
+- Schema-first tools -- typed contracts that let sub-agents discover and validate tools
+- Deterministic boundary -- separating LLM reasoning from testable execution
+- Seven coordination patterns -- fan-out/fan-in, sequential pipeline, recursive delegation, work-stealing queue, map-reduce, peer collaboration, MAKER (million-step zero-error)
+- Foundational patterns -- event-sourcing, hierarchical IDs, agent state machines
+- Tool coordination -- permission inheritance, locking, rate limiting, caching
+- Agent collaboration -- subagent spawning, tool inheritance, sub-agent as tool
+- Lifecycle management -- cascading stop, orphan detection, heartbeat monitoring
+- Self-modification safety -- when and how sub-agents can modify themselves or each other
+- Production hardening -- checkpointing, monitoring, cost tracking across agent hierarchies
+
+## When to use
+
+- Designing systems where multiple AI agents coordinate
+- Implementing orchestrators that spawn sub-agents
+- Building parallel or sequential agent workflows
+- Coordinating shared resources across agents
+- Managing agent lifecycle and state
+
+## Quick example
+
+```typescript
+// Four-layer architecture for each agent
+const parentAgent = new Agent({
+  model: 'sonnet',  // Layer 1: Reasoning
+  tools: [editTool, readTool, bashTool],  // Layer 3: Tool bus with schemas
+  permissions: ['file:read', 'file:write']  // Layer 2: Orchestration policy
+});
+
+// Fan-out/fan-in pattern: spawn specialist sub-agents
+const reviewers = [
+  { type: 'security', model: 'smart', tools: [readTool] },
+  { type: 'performance', model: 'fast', tools: [readTool] },
+  { type: 'style', model: 'fast', tools: [readTool] },
+  { type: 'tests', model: 'smart', tools: [readTool, bashTool] }
+];
+
+// Spawn with permission inheritance (read-only for reviewers)
+const results = await Promise.all(
+  reviewers.map(r => parentAgent.spawnSubAgent({
+    name: r.type,
+    model: r.model,
+    tools: r.tools,
+    permissions: ['file:read'],  // Cannot write - safer
+    timeout: 120000
+  }))
+);
+
+// Cascading cleanup with heartbeat monitoring
+async function cleanup() {
+  const children = await getChildAgents();
+  await Promise.all(children.map(c => c.stop()));
+  await this.stop();
+}
+```
+
+## Discovery questions
+
+Before architecting, the skill asks:
+
+1. Starting point -- greenfield, adding to existing, or fixing current?
+2. Primary use case -- parallel work, pipeline, delegation, collaboration, queue?
+3. Scale expectations -- small (2-5), medium (10-50), large (100+)?
+4. State requirements -- stateless, session-based, or persistent?
+5. Tool coordination -- independent, shared read-only, write coordination, rate-limited?
+6. Existing constraints -- language, framework, performance, compliance?
+
+## Common pitfalls
+
+- Missing four-layer architecture -> untestable, unsafe agents
+- LLM calls in tools -> non-deterministic, untestable execution
+- No schema-first design -> sub-agents can't discover tools
+- Missing cascading stop -> orphaned agents consuming resources
+- No permission inheritance -> sub-agents escalate privileges
+- No timeouts -> indefinite hangs
+- Unbounded concurrency -> resource exhaustion
+- Ignoring cost tracking -> budget surprises across agent hierarchy
+- No partial-failure handling -> cascading failures
+- Unpersisted state -> unrecoverable workflows
+- Uncoordinated tool access -> race conditions
+- Wrong model selection -> cost inefficiency
+- Self-modification without safety protocol -> agents break themselves
+
+## Documentation
+
+See [skills/SKILL.md](skills/SKILL.md) for the complete architecture patterns and implementation guidance.
+
+## Philosophy
+
+Production-ready patterns over improvisation. Every pattern here addresses a real failure mode from a production system.
+
+---
+
+If these patterns helped you build a better multi-agent system, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/ceo-personal-os/index.html
+++ b/docs/plugins/ceo-personal-os/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/ceo-personal-os/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/ceo-personal-os/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/ceo-personal-os/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/ceo-personal-os/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/ceo-personal-os/">
   <meta property="og:title" content="ceo-personal-os — Personal & Strategy Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Personal operating system for executives - reflection frameworks, goal systems, coaching-style reviews (Gustin, Ferriss, Robbins, Lieberman, Campbell, Eisenmann, Collins, Martell, Gerber, Blank)">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/ceo-personal-os/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/ceo-personal-os/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/ceo-personal-os/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/ceo-personal-os/">
   <meta property="twitter:title" content="ceo-personal-os — Personal & Strategy Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Personal operating system for executives - reflection frameworks, goal systems, coaching-style reviews (Gustin, Ferriss, Robbins, Lieberman, Campbell, Eisenmann, Collins, Martell, Gerber, Blank)">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/ceo-personal-os/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/ceo-personal-os/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -282,6 +285,7 @@
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -310,10 +314,12 @@
     "url": "https://2389.ai"
   },
   "description": "Personal operating system for executives - reflection frameworks, goal systems, coaching-style reviews (Gustin, Ferriss, Robbins, Lieberman, Campbell, Eisenmann, Collins, Martell, Gerber, Blank)",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/ceo-personal-os/",
+  "url": "https://skills.2389.ai/plugins/ceo-personal-os/",
   "downloadUrl": "https://github.com/2389-research/ceo-personal-os",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -333,13 +339,13 @@
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "ceo-personal-os",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/ceo-personal-os/"
+      "item": "https://skills.2389.ai/plugins/ceo-personal-os/"
     }
   ]
 }

--- a/docs/plugins/ceo-personal-os/index.md
+++ b/docs/plugins/ceo-personal-os/index.md
@@ -1,0 +1,106 @@
+# ceo-personal-os
+
+> Personal operating system for executives - reflection frameworks, goal systems, coaching-style reviews (Gustin, Ferriss, Robbins, Lieberman, Campbell, Eisenmann, Collins, Martell, Gerber, Blank)
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/ceo-personal-os
+- **Install:** `/plugin install 2389-research/ceo-personal-os`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/ceo-personal-os
+```
+
+## README
+
+# CEO Personal OS Plugin
+
+Reflection frameworks, goal systems, and coaching-style reviews for executives. This builds a reflection system, not a task manager.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install ceo-personal-os@2389-research
+```
+
+## What this plugin provides
+
+### Skills
+
+- `ceo-personal-os` -- methodology for building an executive reflection system with specific frameworks and review cadences
+
+### Frameworks included
+
+| Framework | Credit | Purpose |
+|-----------|--------|---------|
+| Annual Review | Dr. Anthony Gustin | Comprehensive year reflection |
+| Ideal Lifestyle Costing | Tim Ferriss | Design life by cost |
+| Vivid Vision | Tony Robbins | 3-year future visualization |
+| Life Map | Alex Lieberman | 6-domain life balance |
+| Coaching Principles | Bill Campbell | People-first leadership & team development |
+| Startup Failure Patterns | Tom Eisenmann | Detect failure patterns before they kill your venture |
+| Good to Great | Jim Collins | Level 5 Leadership, Hedgehog Concept, Flywheel |
+| Buy Back Your Time | Dan Martell | Reclaim time through delegation, Production Quadrant |
+| E-Myth | Michael Gerber | Work ON your business not IN it, build systems |
+| Customer Development | Steve Blank | Search vs Execute, Get Out of the Building, MVP |
+
+## Quick example
+
+Start with: "Help me build a personal operating system"
+
+The skill generates a complete structure:
+```
+ceo-personal-os/
+├── frameworks/          # 10 specific frameworks
+├── interviews/          # 10 coach-style question scripts
+├── reviews/             # Daily/weekly/quarterly/annual
+├── goals/               # 1/3/10 year horizons
+├── memory.md            # Pattern extraction
+└── principles.md        # Core operating principles
+```
+
+## Core principle
+
+Clarity over productivity theater. No hustle culture. No corporate jargon. The output should feel like talking to an executive coach who is calm, direct, and asks good questions.
+
+## Review cadences
+
+| Cadence | Time | Focus |
+|---------|------|-------|
+| Daily | 5 min | Energy + one win + one friction |
+| Weekly | 30-45 min | What moved the needle? |
+| Quarterly | 2-3 hours | Goal alignment check |
+| Annual | 4-6 hours | Full Gustin-style reflection |
+
+## When this skill applies
+
+- "I want a personal operating system"
+- "Help me with my annual review"
+- Building goal-setting systems for executives
+- Life planning and reflection frameworks
+- Mentions of Gustin, Ferriss, Robbins, Lieberman, or Campbell frameworks
+- "How do I develop my people?" or team-first leadership questions
+- Mentions of "Trillion Dollar Coach" or Bill Campbell
+- "Why do startups fail?" or Eisenmann startup failure patterns
+- Evaluating venture health or deciding when to pivot/quit
+- Mentions of "Good to Great", Level 5 Leadership, or Hedgehog Concept
+- "How do I buy back my time?" or Dan Martell frameworks
+- "I'm stuck working IN instead of ON my business" or E-Myth concepts
+- Stuck doing technical work instead of strategic leadership
+- Mentions of Customer Development, Steve Blank, or "get out of the building"
+- Questions about MVP, pivot decisions, or product-market fit
+- "Are we searching or executing?" or early-stage startup strategy
+
+## Links
+
+- [Plugin CLAUDE.md](./CLAUDE.md) -- development instructions
+
+---
+
+If this helped you build a better operating system for your work, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/css-development/index.html
+++ b/docs/plugins/css-development/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/css-development/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/css-development/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/css-development/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/css-development/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/css-development/">
   <meta property="og:title" content="css-development — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="CSS development workflows with Tailwind composition, semantic naming, and dark mode by default">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/css-development/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/css-development/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/css-development/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/css-development/">
   <meta property="twitter:title" content="css-development — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="CSS development workflows with Tailwind composition, semantic naming, and dark mode by default">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/css-development/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/css-development/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -279,6 +282,7 @@
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -307,10 +311,12 @@
     "url": "https://2389.ai"
   },
   "description": "CSS development workflows with Tailwind composition, semantic naming, and dark mode by default",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/css-development/",
+  "url": "https://skills.2389.ai/plugins/css-development/",
   "downloadUrl": "https://github.com/2389-research/css-development",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -330,13 +336,13 @@
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "css-development",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/css-development/"
+      "item": "https://skills.2389.ai/plugins/css-development/"
     }
   ]
 }

--- a/docs/plugins/css-development/index.md
+++ b/docs/plugins/css-development/index.md
@@ -1,0 +1,74 @@
+# css-development
+
+> CSS development workflows with Tailwind composition, semantic naming, and dark mode by default
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/css-development
+- **Install:** `/plugin install 2389-research/css-development`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/css-development
+```
+
+## README
+
+# CSS Development Plugin
+
+CSS development workflows with Tailwind composition, semantic naming, and dark mode by default.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install css-development@2389-research
+```
+
+## What this plugin provides
+
+Skills for CSS development following 2389 patterns:
+
+- `css-development` -- main orchestrator skill that routes to specific sub-skills
+- `css-development:create-component` -- create new styled components
+- `css-development:validate` -- validate CSS against patterns
+- `css-development:refactor` -- refactor existing CSS
+
+## Patterns
+
+This plugin enforces:
+
+- Semantic class naming -- `.user-profile`, `.nav-menu` (not `.container-1`, `.box-blue`)
+- Tailwind composition -- use `@apply` to compose utilities into semantic classes
+- Dark mode by default -- every component includes `dark:` variants
+- Test coverage -- static analysis + component rendering tests
+
+## Quick example
+
+```css
+.user-profile {
+  @apply flex items-center space-x-4 p-4 bg-white dark:bg-gray-800;
+}
+
+.user-profile__avatar {
+  @apply w-12 h-12 rounded-full;
+}
+
+.user-profile__name {
+  @apply text-lg font-semibold text-gray-900 dark:text-gray-100;
+}
+```
+
+## Documentation
+
+- [Design document](docs/plans/2025-11-13-css-development-skill-design.md)
+- [Implementation plan](docs/plans/2025-11-13-css-development-skill-implementation.md)
+- [Examples](docs/examples/css-development-examples.md)
+
+---
+
+If these CSS workflows saved you from fighting Tailwind, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/deliberation/index.html
+++ b/docs/plugins/deliberation/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/deliberation/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/deliberation/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/deliberation/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/deliberation/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/deliberation/">
   <meta property="og:title" content="deliberation — Agent Systems Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Decision-making through deliberation - seeking unity through discernment rather than consensus through debate">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/deliberation/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/deliberation/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/deliberation/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/deliberation/">
   <meta property="twitter:title" content="deliberation — Agent Systems Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Decision-making through deliberation - seeking unity through discernment rather than consensus through debate">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/deliberation/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/deliberation/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -294,6 +297,7 @@ Business Strategist, Developer Culture voice. Anyone to add?"
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -322,10 +326,12 @@ Business Strategist, Developer Culture voice. Anyone to add?"
     "url": "https://2389.ai"
   },
   "description": "Decision-making through deliberation - seeking unity through discernment rather than consensus through debate",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/deliberation/",
+  "url": "https://skills.2389.ai/plugins/deliberation/",
   "downloadUrl": "https://github.com/2389-research/deliberation",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -345,13 +351,13 @@ Business Strategist, Developer Culture voice. Anyone to add?"
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "deliberation",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/deliberation/"
+      "item": "https://skills.2389.ai/plugins/deliberation/"
     }
   ]
 }

--- a/docs/plugins/deliberation/index.md
+++ b/docs/plugins/deliberation/index.md
@@ -1,0 +1,102 @@
+# deliberation
+
+> Decision-making through deliberation - seeking unity through discernment rather than consensus through debate
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/deliberation
+- **Install:** `/plugin install 2389-research/deliberation`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/deliberation
+```
+
+## README
+
+# Deliberation
+
+Most AI tools give you answers. Deliberation gives you perspectives. When you're facing a decision with real weight — architecture choices, ethical trade-offs, competing approaches — this skill convenes voices that seek clarity instead of racing to conclusions.
+
+[Read how we built this →](https://2389.ai/posts/deliberation-perspectives-not-answers/)
+
+*Inspired by Quaker business practice, adapted for AI-assisted decision-making.*
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install deliberation@2389-research
+```
+
+## Skills
+
+- `deliberation` -- main router skill
+- `deliberation:discernment` -- internal voices seeking clarity
+- `deliberation:clearness` -- multi-agent committee for deep analysis
+- `deliberation:gathered` -- participatory discernment with user
+
+## Quick example
+
+```
+User: "Should we open-source our internal tool? I've been thinking about this for weeks."
+
+Claude (with deliberation:gathered): "You've been sitting with this for weeks - you have
+a perspective, not just a question. Want to discern this together?
+
+Here are the ground rules: You speak once. You don't have to speak.
+Don't react, discern. This is slow, and that's the point.
+
+I'd suggest these perspectives alongside yours: Community Builder,
+Business Strategist, Developer Culture voice. Anyone to add?"
+```
+
+## Skills in detail
+
+### deliberation:discernment
+
+Internal deliberation where Claude convenes multiple perspectives (voices) to discern the right path forward. Use for weighty questions, ethical decisions, and trade-offs.
+
+It identifies context-relevant perspectives, has each voice speak once to the matter, then a clerk role synthesizes toward unity. Tensions get surfaced, not papered over.
+
+### deliberation:clearness
+
+Multi-agent committee that spawns specialized agents for parallel deep analysis. Use for code reviews, architecture decisions, and research requiring depth.
+
+The skill proposes committee composition (user confirms), spawns agents with specific perspectives, runs real parallel analysis, and has a clerk synthesize findings toward unity.
+
+### deliberation:gathered
+
+Participatory discernment where the user joins alongside agent voices. Use when the user has a stake or perspective, not just a question.
+
+It recognizes when the user has stake/perspective, teaches the discipline (speak once, silence is meaningful, slow is the point), runs sequential agent voices with check-ins, and lets the user's contribution shape the synthesis.
+
+## Principles
+
+These skills draw on contemplative decision-making traditions:
+
+| Principle | Meaning |
+|-----------|---------|
+| Sense of the meeting | Discern where unity lies, don't count votes |
+| Speaking once | Each perspective speaks once, then listens |
+| Silence | Space between voices lets insights emerge |
+| Standing aside | Disagree but don't block ("I wouldn't, but I won't stop you") |
+| Blocking | Rare -- only for violations of core principles |
+| Way opens | Recognize when clarity emerges vs. forcing decision |
+
+## Development
+
+Skills were developed using TDD for documentation:
+1. Baseline tests (pressure scenarios without skill)
+2. Document failures (how Claude responds without guidance)
+3. Write skill addressing specific failures
+4. Test with skill (verify improvement)
+5. Iterate until solid
+
+---
+
+If Deliberation helped you make a better decision (or avoid a bad one), a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/documentation-audit/index.html
+++ b/docs/plugins/documentation-audit/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/documentation-audit/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/documentation-audit/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/documentation-audit/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/documentation-audit/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/documentation-audit/">
   <meta property="og:title" content="documentation-audit — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/documentation-audit/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/documentation-audit/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/documentation-audit/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/documentation-audit/">
   <meta property="twitter:title" content="documentation-audit — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/documentation-audit/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/documentation-audit/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -257,6 +260,7 @@
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -285,10 +289,12 @@
     "url": "https://2389.ai"
   },
   "description": "Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/documentation-audit/",
+  "url": "https://skills.2389.ai/plugins/documentation-audit/",
   "downloadUrl": "https://github.com/2389-research/documentation-audit",
   "softwareVersion": "2.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -308,13 +314,13 @@
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "documentation-audit",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/documentation-audit/"
+      "item": "https://skills.2389.ai/plugins/documentation-audit/"
     }
   ]
 }

--- a/docs/plugins/documentation-audit/index.md
+++ b/docs/plugins/documentation-audit/index.md
@@ -1,0 +1,32 @@
+# documentation-audit
+
+> Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection
+
+- **Version:** 2.0.0
+- **Source:** https://github.com/2389-research/documentation-audit
+- **Install:** `/plugin install 2389-research/documentation-audit`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/documentation-audit
+```
+
+## README
+
+
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install documentation-audit@2389-research
+```
+
+---
+
+If Documentation Audit caught a lie in your docs, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/firebase-development/index.html
+++ b/docs/plugins/firebase-development/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/firebase-development/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/firebase-development/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/firebase-development/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/firebase-development/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/firebase-development/">
   <meta property="og:title" content="firebase-development — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Firebase project workflows including setup, features, debugging, and validation">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/firebase-development/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/firebase-development/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/firebase-development/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/firebase-development/">
   <meta property="twitter:title" content="firebase-development — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Firebase project workflows including setup, features, debugging, and validation">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/firebase-development/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/firebase-development/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -277,6 +280,7 @@ export const users = {
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -305,10 +309,12 @@ export const users = {
     "url": "https://2389.ai"
   },
   "description": "Firebase project workflows including setup, features, debugging, and validation",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/firebase-development/",
+  "url": "https://skills.2389.ai/plugins/firebase-development/",
   "downloadUrl": "https://github.com/2389-research/firebase-development",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -328,13 +334,13 @@ export const users = {
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "firebase-development",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/firebase-development/"
+      "item": "https://skills.2389.ai/plugins/firebase-development/"
     }
   ]
 }

--- a/docs/plugins/firebase-development/index.md
+++ b/docs/plugins/firebase-development/index.md
@@ -1,0 +1,75 @@
+# firebase-development
+
+> Firebase project workflows including setup, features, debugging, and validation
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/firebase-development
+- **Install:** `/plugin install 2389-research/firebase-development`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/firebase-development
+```
+
+## README
+
+# Firebase development plugin
+
+Firebase project workflows including setup, features, debugging, and validation.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install firebase-development@2389-research
+```
+
+## What this plugin provides
+
+Skills for Firebase development following 2389 patterns:
+
+- `firebase-development` -- main orchestrator skill that routes to specific sub-skills
+- `firebase-development:project-setup` -- initialize new Firebase projects
+- `firebase-development:add-feature` -- add features to existing projects
+- `firebase-development:debug` -- debug Firebase issues
+- `firebase-development:validate` -- validate project structure
+
+## Patterns
+
+This plugin supports multi-hosting (multiple sites or single), authentication via custom API keys or Firebase Auth or both, Cloud Functions organized as Express apps or domain-grouped or individual files, and server-write-only vs client-write security models.
+
+Development is emulator-first -- always test locally before deploying. Tooling is TypeScript, vitest, and biome.
+
+## Quick example
+
+```typescript
+// Cloud Function with domain grouping
+export const users = {
+  onCreate: onDocumentCreated('users/{userId}', async (event) => {
+    // Implementation
+  }),
+  onUpdate: onDocumentUpdated('users/{userId}', async (event) => {
+    // Implementation
+  })
+};
+```
+
+## Documentation
+
+- [Design Document](docs/plans/2025-01-14-firebase-skills-design.md)
+- [Implementation Plan](docs/plans/2025-01-14-firebase-skills-implementation.md)
+- Examples:
+  - [API Key Authentication](docs/examples/api-key-authentication.md)
+  - [Emulator Workflow](docs/examples/emulator-workflow.md)
+  - [Express Function Architecture](docs/examples/express-function-architecture.md)
+  - [Firestore Rules Patterns](docs/examples/firestore-rules-patterns.md)
+  - [Multi-Hosting Setup](docs/examples/multi-hosting-setup.md)
+
+---
+
+If these Firebase workflows saved you from emulator hell, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/fresh-eyes-review/index.html
+++ b/docs/plugins/fresh-eyes-review/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/fresh-eyes-review/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/fresh-eyes-review/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/fresh-eyes-review/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/fresh-eyes-review/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/fresh-eyes-review/">
   <meta property="og:title" content="fresh-eyes-review — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Mandatory final sanity check before commits/PRs - catches security vulnerabilities, logic errors, and bugs that slip through tests">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/fresh-eyes-review/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/fresh-eyes-review/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/fresh-eyes-review/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/fresh-eyes-review/">
   <meta property="twitter:title" content="fresh-eyes-review — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Mandatory final sanity check before commits/PRs - catches security vulnerabilities, logic errors, and bugs that slip through tests">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/fresh-eyes-review/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/fresh-eyes-review/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -283,6 +286,7 @@
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -311,10 +315,12 @@
     "url": "https://2389.ai"
   },
   "description": "Mandatory final sanity check before commits/PRs - catches security vulnerabilities, logic errors, and bugs that slip through tests",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/fresh-eyes-review/",
+  "url": "https://skills.2389.ai/plugins/fresh-eyes-review/",
   "downloadUrl": "https://github.com/2389-research/fresh-eyes-review",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -334,13 +340,13 @@
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "fresh-eyes-review",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/fresh-eyes-review/"
+      "item": "https://skills.2389.ai/plugins/fresh-eyes-review/"
     }
   ]
 }

--- a/docs/plugins/fresh-eyes-review/index.md
+++ b/docs/plugins/fresh-eyes-review/index.md
@@ -1,0 +1,83 @@
+# fresh-eyes-review
+
+> Mandatory final sanity check before commits/PRs - catches security vulnerabilities, logic errors, and bugs that slip through tests
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/fresh-eyes-review
+- **Install:** `/plugin install 2389-research/fresh-eyes-review`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/fresh-eyes-review
+```
+
+## README
+
+# Fresh-eyes review
+
+Mandatory sanity check before git commit or PR creation.
+
+> "Tests are comprehensive." "I'm confident it's correct." "Partner is waiting." "Production is blocked." "Senior dev already approved."
+>
+> These are exactly the circumstances when critical bugs escape into production.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install fresh-eyes-review@2389-research
+```
+
+## What this plugin does
+
+A disciplined review process that catches security holes, logic errors, edge cases, and business logic bugs that slip through despite passing tests.
+
+### Core principle
+
+**"NO COMMIT WITHOUT FRESH-EYES REVIEW FIRST"**
+
+This runs *after* implementation, *after* tests pass, but *before* code ships.
+
+## What it catches
+
+- Security vulnerabilities -- SQL injection, XSS, path traversal, command injection
+- Logic errors -- off-by-one boundaries, race conditions, null handling
+- Business rule bugs -- calculations not matching requirements
+- Input validation gaps -- missing type, range, or format checks
+- Performance problems -- N+1 queries, unbounded loops
+
+## Quick example
+
+```
+Before committing code:
+1. "Starting fresh-eyes review of 3 files. This will take 2-5 minutes."
+2. Review systematically for security, logic, business rules, validation, performance
+3. Fix issues immediately and re-run tests
+4. "Fresh-eyes complete. 2 issues found and fixed."
+```
+
+## Why bother
+
+**"100% test coverage and passing scenarios" can coexist with critical bugs** waiting to be discovered.
+
+Testing, code review, and fresh-eyes review are different things. Testing validates expected behavior under controlled conditions. Code review examines patterns and quality during implementation. Fresh-eyes catches unexpected issues through deliberate re-reading -- you're looking at the code with psychological distance.
+
+## Time commitment
+
+Expected duration: **2-5 minutes** depending on file count.
+
+- If you finish faster than that, you probably didn't look hard enough
+- If it takes much longer, you're probably scope-creeping
+
+## Documentation
+
+See [skills/SKILL.md](skills/SKILL.md) for the complete fresh-eyes review protocol.
+
+---
+
+If Fresh Eyes caught something your tests didn't, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/git-repo-prep/index.html
+++ b/docs/plugins/git-repo-prep/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/git-repo-prep/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/git-repo-prep/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/git-repo-prep/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/git-repo-prep/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/git-repo-prep/">
   <meta property="og:title" content="git-repo-prep — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Prepare codebases for public/open-source release and audit them for openness - full lifecycle prep or standalone review">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/git-repo-prep/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/git-repo-prep/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/git-repo-prep/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/git-repo-prep/">
   <meta property="twitter:title" content="git-repo-prep — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Prepare codebases for public/open-source release and audit them for openness - full lifecycle prep or standalone review">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/git-repo-prep/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/git-repo-prep/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -279,6 +282,7 @@
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -307,10 +311,12 @@
     "url": "https://2389.ai"
   },
   "description": "Prepare codebases for public/open-source release and audit them for openness - full lifecycle prep or standalone review",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/git-repo-prep/",
+  "url": "https://skills.2389.ai/plugins/git-repo-prep/",
   "downloadUrl": "https://github.com/2389-research/git-repo-prep",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -330,13 +336,13 @@
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "git-repo-prep",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/git-repo-prep/"
+      "item": "https://skills.2389.ai/plugins/git-repo-prep/"
     }
   ]
 }

--- a/docs/plugins/git-repo-prep/index.md
+++ b/docs/plugins/git-repo-prep/index.md
@@ -1,0 +1,70 @@
+# git-repo-prep
+
+> Prepare codebases for public/open-source release and audit them for openness - full lifecycle prep or standalone review
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/git-repo-prep
+- **Install:** `/plugin install 2389-research/git-repo-prep`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/git-repo-prep
+```
+
+## README
+
+# git-repo-prep
+
+Prepare codebases for public/open-source release and audit them for openness.
+
+## Installation
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install git-repo-prep@2389-research
+```
+
+## What This Plugin Does
+
+Two modes:
+
+**Prepare** — Full lifecycle walking through 9 phases interactively:
+1. Discovery (detect ecosystem, scan structure)
+2. Secrets & personal info audit
+3. License selection and consistency
+4. Documentation (README, CONTRIBUTING, SECURITY)
+5. Gitignore refinement
+6. Project hardening (CI/CD, dependabot, hooks)
+7. Repository metadata
+8. Backlog & honesty
+9. Final review
+
+**Review** — Standalone openness audit, re-runnable anytime. Scans for secrets, personal info, license issues, missing docs, gitignore gaps, CI/CD, and metadata. Presents findings by severity (critical/recommended/nice-to-have) and offers to fix each issue.
+
+## Usage
+
+```
+"Prepare this repo for open-source release"    → full lifecycle
+"Review this repo for openness"                → standalone audit
+```
+
+## Ecosystem Support
+
+Agnostic core with specific hints for Node.js, Python, Rust, Go, .NET, Ruby, and Java/Kotlin.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `git-repo-prep` | Router — detects intent, dispatches |
+| `git-repo-prep:prepare` | Full 9-phase open-source prep lifecycle |
+| `git-repo-prep:review` | Standalone openness audit |
+
+---
+
+If Git Repo Prep caught something before you went public, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/jam/index.html
+++ b/docs/plugins/jam/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/jam/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/jam/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/jam/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/jam/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/jam/">
   <meta property="og:title" content="jam — Agent Systems Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Parallel exploration powered by diverse perspectives - independent agent panels propose, build variants in worktrees, review, pick a winner, and synthesize the best of all variants into the final result">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/jam/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/jam/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/jam/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/jam/">
   <meta property="twitter:title" content="jam — Agent Systems Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Parallel exploration powered by diverse perspectives - independent agent panels propose, build variants in worktrees, review, pick a winner, and synthesize the best of all variants into the final result">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/jam/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/jam/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -319,6 +322,7 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -347,10 +351,12 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
     "url": "https://2389.ai"
   },
   "description": "Parallel exploration powered by diverse perspectives - independent agent panels propose, build variants in worktrees, review, pick a winner, and synthesize the best of all variants into the final result",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/jam/",
+  "url": "https://skills.2389.ai/plugins/jam/",
   "downloadUrl": "https://github.com/2389-research/jam",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -370,13 +376,13 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "jam",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/jam/"
+      "item": "https://skills.2389.ai/plugins/jam/"
     }
   ]
 }

--- a/docs/plugins/jam/index.md
+++ b/docs/plugins/jam/index.md
@@ -1,0 +1,128 @@
+# jam
+
+> Parallel exploration powered by diverse perspectives - independent agent panels propose, build variants in worktrees, review, pick a winner, and synthesize the best of all variants into the final result
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/jam
+- **Install:** `/plugin install 2389-research/jam`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/jam
+```
+
+## README
+
+# Jam
+
+**Parallel exploration powered by diverse perspectives.**
+
+Jam is a [Claude Code](https://claude.com/claude-code) plugin that turns "build me X" into a structured exploration: diverse panels propose approaches, variants get built in parallel, a review panel evaluates them all, and the best insights from every variant get folded into the winner.
+
+> The jam was all of us together.
+
+## Why
+
+A single agent generating "multiple approaches" is still one mind imagining what different people would think. The perspectives cluster, biases leak through, and the agent converges to its own preference. Jam makes diversity real by dispatching independent agents who reason separately — and then it refuses to throw away what the losers figured out.
+
+## The flow
+
+```
+Build request
+    ↓
+Context & architectural slots
+    ↓
+Generate a domain-specific perspective panel  ← diverse independent agents
+    ↓
+Synthesize proposals into 3–5 distinct variants
+    ↓
+Implement all variants in parallel (git worktrees)
+    ↓
+Generate a domain-specific review panel        ← diverse independent reviewers
+    ↓
+Review panel evaluates ALL variants
+    ↓
+Pick winner based on panel findings
+    ↓
+Synthesize: fold best insights from ALL variants into the winner
+    ↓
+Ship the improved winner
+```
+
+Two things make this different from plain brainstorming:
+
+1. **Real diversity, not imagined diversity.** Panels are independent agents, each with a different worldview and optimization function. They never see each other's output.
+2. **Active synthesis, not a backlog.** The strengths of losing variants get ported into the winner *now*, not documented for "later."
+
+## Installation
+
+Add the marketplace and install:
+
+```bash
+# In Claude Code
+/plugin marketplace add 2389-research/marketplace
+/plugin install jam@2389-research-marketplace
+```
+
+Or install directly from this repo as a dev plugin:
+
+```bash
+claude --plugin-dir /path/to/jam
+```
+
+## Usage
+
+Just ask Claude to jam on something:
+
+- "jam on a fizzbuzz CLI"
+- "let's jam on the onboarding flow"
+- "can we jam on the storage layer?"
+- "jam this design with a few different approaches"
+
+Claude will:
+1. Ask 1–2 context questions and identify the architectural slots worth exploring
+2. Propose a domain-specific perspective panel for your approval
+3. Dispatch the panel, synthesize proposals into variants, get your approval
+4. Implement all variants in parallel in git worktrees
+5. Propose a review panel for your approval
+6. Dispatch reviewers against every variant
+7. Pick a winner, propose a synthesis plan, then implement the improvements
+8. Clean up losing worktrees and hand you the final branch
+
+You stay in the loop at every gate — panels and synthesis plans are always presented before execution.
+
+## When to use it
+
+**Good fit:**
+- Build/create/implement requests where multiple approaches are genuinely viable
+- Architectural decisions with real trade-offs
+- You're indecisive or want to see options
+- You want more than one mind on the problem
+
+**Bad fit:**
+- Trivial changes (rename, config tweak, tiny bugfix)
+- You already know exactly what you want
+- Single clear path with no meaningful alternatives
+
+## Repo layout
+
+```
+.claude-plugin/plugin.json   Plugin manifest
+CLAUDE.md                    Agent-facing plugin guide
+AGENTS.md                    Same, for non-Claude agents
+skills/
+  SKILL.md                   Router skill
+  jam/SKILL.md               The full Jam workflow
+evals/                       Comparative eval harness (Jam vs. other approaches)
+```
+
+## Evals
+
+The `evals/` directory contains a harness that runs tasks against multiple approaches (plain Claude, brainstorming, test-kitchen, jam) and compares the outputs. See `evals/run-eval.sh`.
+
+## License
+
+MIT
+

--- a/docs/plugins/journal/index.html
+++ b/docs/plugins/journal/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/journal/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/journal/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/journal/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/journal/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/journal/">
   <meta property="og:title" content="journal — Personal & Strategy Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/journal/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/journal/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/journal/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/journal/">
   <meta property="twitter:title" content="journal — Personal & Strategy Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/journal/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/journal/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -136,7 +139,7 @@
 <ul><li><strong>Jest</strong> - Comprehensive testing framework with mocks</li><li><strong>Biome</strong> - Modern linting and formatting</li><li><strong>Oxlint</strong> - Additional code quality checks</li><li><strong>GitHub Actions</strong> - Continuous integration and testing</li></ul>
 <h4>Storage & Architecture</h4>
 <ul><li><strong>Markdown + YAML</strong> - Human-readable entries with structured metadata</li><li><strong>Hierarchical File System</strong> - Date-based organization with microsecond precision</li><li><strong>Cross-Platform</strong> - Windows, macOS, and Linux support</li></ul>
-<p>For detailed architectural decisions, see <a href="ARCHITECTURE.md" rel="noopener noreferrer">ARCHITECTURE.md</a>.</p>
+<p>For detailed architectural decisions, see <a href="https://github.com/2389-research/journal-mcp/blob/main/ARCHITECTURE.md" rel="noopener noreferrer" target="_blank">ARCHITECTURE.md</a>.</p>
 <h3>Installation</h3>
 <pre><code class="language-bash">npm install -g private-journal-mcp
 </code></pre>
@@ -292,7 +295,7 @@ Vector embeddings provide semantic understanding...
 <p>This enables Claude to build persistent memory across conversations, leading to better engineering decisions and collaboration patterns.</p>
 <h3>Documentation</h3>
 <h4>Comprehensive Guides</h4>
-<ul><li><strong><a href="ARCHITECTURE.md" rel="noopener noreferrer">Architecture & Design Decisions</a></strong> - Technical architecture, design patterns, and key decisions</li><li><strong><a href="CONTRIBUTING.md" rel="noopener noreferrer">Contributing Guidelines</a></strong> - Development setup, code style, testing, and contribution process</li><li><strong><a href="ROADMAP.md" rel="noopener noreferrer">Roadmap & Development Priorities</a></strong> - Current status, planned features, and future direction</li></ul>
+<ul><li><strong><a href="https://github.com/2389-research/journal-mcp/blob/main/ARCHITECTURE.md" rel="noopener noreferrer" target="_blank">Architecture & Design Decisions</a></strong> - Technical architecture, design patterns, and key decisions</li><li><strong><a href="https://github.com/2389-research/journal-mcp/blob/main/CONTRIBUTING.md" rel="noopener noreferrer" target="_blank">Contributing Guidelines</a></strong> - Development setup, code style, testing, and contribution process</li><li><strong><a href="https://github.com/2389-research/journal-mcp/blob/main/ROADMAP.md" rel="noopener noreferrer" target="_blank">Roadmap & Development Priorities</a></strong> - Current status, planned features, and future direction</li></ul>
 <h4>API Reference</h4>
 <ul><li><strong><a href="https://github.com/2389-research/journal-mcp/blob/main/docs/spec.md" rel="noopener noreferrer" target="_blank">docs/spec.md</a></strong> - Original MCP server specification</li><li><strong><a href="https://github.com/2389-research/journal-mcp/blob/main/docs/backend-api-spec.md" rel="noopener noreferrer" target="_blank">docs/backend-api-spec.md</a></strong> - Remote server API documentation</li><li><strong><a href="https://github.com/2389-research/journal-mcp/blob/main/docs/implementation-plan.md" rel="noopener noreferrer" target="_blank">docs/implementation-plan.md</a></strong> - Development history and implementation details</li></ul>
 <h4>Getting Help</h4>
@@ -437,6 +440,7 @@ Vector embeddings provide semantic understanding...
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -465,10 +469,12 @@ Vector embeddings provide semantic understanding...
     "url": "https://2389.ai"
   },
   "description": "A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/journal/",
+  "url": "https://skills.2389.ai/plugins/journal/",
   "downloadUrl": "https://github.com/2389-research/journal-mcp",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -488,13 +494,13 @@ Vector embeddings provide semantic understanding...
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "journal",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/journal/"
+      "item": "https://skills.2389.ai/plugins/journal/"
     }
   ]
 }

--- a/docs/plugins/journal/index.md
+++ b/docs/plugins/journal/index.md
@@ -1,0 +1,360 @@
+# journal
+
+> A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/journal-mcp
+- **Install:** `/plugin install 2389-research/journal`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/journal
+```
+
+## README
+
+# Private Journal MCP Server
+
+[![Test Coverage](https://github.com/2389-research/journal-mcp/actions/workflows/coverage.yml/badge.svg)](https://github.com/2389-research/journal-mcp/actions/workflows/coverage.yml)
+[![Coverage](https://img.shields.io/badge/coverage-86.8%25-brightgreen)](https://github.com/2389-research/journal-mcp/actions)
+
+A comprehensive MCP (Model Context Protocol) server that provides Claude with private journaling and semantic search capabilities for processing thoughts, feelings, and insights.
+
+## Features
+
+### Journaling
+- **Multi-section journaling**: Separate categories for feelings, project notes, user context, technical insights, and world knowledge
+- **Dual storage**: Project notes stay with projects, personal thoughts in user home directory
+- **Timestamped entries**: Each entry automatically dated with microsecond precision
+- **YAML frontmatter**: Structured metadata for each entry
+
+### Search & Discovery
+- **Semantic search**: Natural language queries using local AI embeddings
+- **Vector similarity**: Find conceptually related entries, not just keyword matches
+- **Local AI processing**: Uses @xenova/transformers - no external API calls required
+- **Automatic indexing**: Embeddings generated for all entries on startup and ongoing
+
+### Privacy & Performance
+- **Completely private**: All processing happens locally, no data leaves your machine
+- **Fast operation**: Optimized file structure and in-memory similarity calculations
+- **Robust fallbacks**: Intelligent path resolution across platforms
+
+## Tech Stack
+
+### Core Technologies
+- **Node.js 18+** - Runtime environment with modern JavaScript features
+- **TypeScript 5.0+** - Type-safe development with strict configuration
+- **MCP SDK 0.4.0** - Official Model Context Protocol implementation
+- **@xenova/transformers** - Local AI models for semantic embeddings (no external APIs)
+
+### AI & Search
+- **Semantic Embeddings** - Multiple model options (MiniLM, DistilRoBERTa, MPNet)
+- **Vector Similarity** - Local cosine similarity calculations
+- **Natural Language Search** - Query understanding without external services
+
+### Development & Quality
+- **Jest** - Comprehensive testing framework with mocks
+- **Biome** - Modern linting and formatting
+- **Oxlint** - Additional code quality checks
+- **GitHub Actions** - Continuous integration and testing
+
+### Storage & Architecture
+- **Markdown + YAML** - Human-readable entries with structured metadata
+- **Hierarchical File System** - Date-based organization with microsecond precision
+- **Cross-Platform** - Windows, macOS, and Linux support
+
+For detailed architectural decisions, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## Installation
+
+```bash
+npm install -g private-journal-mcp
+```
+
+Or install locally:
+
+```bash
+npm install private-journal-mcp
+```
+
+## Usage
+
+### Basic Usage
+```bash
+private-journal-mcp
+```
+
+This creates journal entries in `.private-journal/` in the current working directory.
+
+### Custom Journal Path
+```bash
+private-journal-mcp --journal-path /path/to/my/journal
+```
+
+### Embedding Model Configuration
+
+You can customize the AI model used for generating semantic embeddings:
+
+```bash
+export JOURNAL_EMBEDDING_MODEL="Xenova/all-distilroberta-v1"
+```
+
+**Available Models:**
+- `Xenova/all-MiniLM-L6-v2` (default) - Fast, 384 dimensions, good general performance
+- `Xenova/all-distilroberta-v1` - Larger, 768 dimensions, better accuracy
+- `Xenova/paraphrase-MiniLM-L6-v2` - Optimized for paraphrase detection
+- `Xenova/all-mpnet-base-v2` - High quality, 768 dimensions, slower but more accurate
+
+The embedding model affects:
+- **Local search quality** - More sophisticated models provide better semantic understanding
+- **Vector dimensions** - Impacts remote server storage and search capabilities
+- **Processing speed** - Larger models are slower but more accurate
+- **Memory usage** - Bigger models require more RAM
+
+### Remote Server Integration
+
+To enable optional remote posting of journal entries to a team server, set these environment variables:
+
+```bash
+export REMOTE_JOURNAL_SERVER_URL="https://api.yourteam.com"
+export REMOTE_JOURNAL_TEAMID="your-team-id"
+export REMOTE_JOURNAL_APIKEY="your-api-key"
+```
+
+When configured, journal entries will be posted to your remote server in addition to being saved locally. Local journaling always takes priority - if the remote posting fails, the local entry is still saved.
+
+#### Remote-Only Mode
+
+For teams using a backend server as the single source of truth, enable remote-only mode to skip local file storage entirely:
+
+```bash
+export REMOTE_JOURNAL_ONLY="true"
+```
+
+In remote-only mode:
+- **No local storage** - entries go directly to the backend server
+- **Server-side search** - all search queries use the backend API
+- **Error handling** - journal operations fail if server is unavailable
+- **Team collaboration** - automatic sharing across team members
+- **Centralized AI** - semantic search powered by backend infrastructure
+
+#### Remote Payload Format
+
+The server sends JSON payloads with this structure:
+
+**For simple entries:**
+```json
+{
+  "team_id": "your-team-id",
+  "timestamp": 1717160645123,
+  "content": "Journal entry text",
+  "embedding": [0.1, 0.2, 0.3, 0.4, 0.5, "..."]
+}
+```
+
+**For structured thoughts:**
+```json
+{
+  "team_id": "your-team-id",
+  "timestamp": 1717160645123,
+  "sections": {
+    "feelings": "I feel great about this feature",
+    "project_notes": "Architecture is solid",
+    "technical_insights": "TypeScript provides great type safety",
+    "user_context": "Harper prefers concise responses",
+    "world_knowledge": "Semantic search is powerful"
+  },
+  "embedding": [0.1, 0.2, 0.3, 0.4, 0.5, "..."]
+}
+```
+
+#### Embedding Vectors
+
+Each journal entry includes a semantic embedding vector generated using local AI models (@xenova/transformers). These vectors enable:
+- **Semantic search** on the remote server
+- **Similarity matching** across team entries
+- **Content clustering** and analysis
+- **AI-powered insights** without exposing raw content
+
+The embedding is a numeric array representing the semantic meaning of the journal entry content. Vector dimensions depend on the model used (typically 384 or 512 dimensions).
+
+The remote server should expect POST requests to `/journal/entries` with `x-api-key` and `x-team-id` headers.
+
+### Claude Code Plugin
+
+This repository is configured as a Claude Code Plugin. To use it:
+
+#### Quick Install (Recommended)
+```bash
+claude mcp add-json private-journal '{"type":"stdio","command":"npx","args":["github:2389-research/journal-mcp"]}' -s user
+```
+
+Or install directly from GitHub:
+```bash
+claude mcp install github:2389-research/journal-mcp
+```
+
+#### What's Included
+
+The plugin provides:
+- **Tools**: `process_thoughts`, `search_journal`, `read_journal_entry`, `list_recent_entries`
+- **Resources**: Access to journal entries as discoverable resources
+- **Prompts**: Guided templates for daily reflection, project retrospectives, and learning capture
+
+### MCP Configuration (Other Clients)
+
+#### Manual Configuration
+For Claude Desktop or other MCP clients, add to your MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "private-journal": {
+      "command": "npx",
+      "args": ["github:2389-research/journal-mcp"]
+    }
+  }
+}
+```
+
+The server will automatically find a suitable location for the journal files.
+
+## MCP Tools
+
+The server provides comprehensive journaling and search capabilities:
+
+### `process_thoughts`
+Multi-section private journaling with these optional categories:
+- **feelings**: Private emotional processing space
+- **project_notes**: Technical insights specific to current project
+- **user_context**: Notes about collaborating with humans
+- **technical_insights**: General software engineering learnings
+- **world_knowledge**: Domain knowledge and interesting discoveries
+
+### `search_journal`
+Semantic search across all journal entries:
+- **query** (required): Natural language search query
+- **limit**: Maximum results (default: 10)
+- **type**: Search scope - 'project', 'user', or 'both' (default: 'both')
+- **sections**: Filter by specific categories
+
+### `read_journal_entry`
+Read full content of specific entries:
+- **path** (required): File path from search results
+
+### `list_recent_entries`
+Browse recent entries chronologically:
+- **limit**: Maximum entries (default: 10)
+- **type**: Entry scope - 'project', 'user', or 'both' (default: 'both')
+- **days**: Days back to search (default: 30)
+
+## File Structure
+
+### Project Journal (per project)
+```
+.private-journal/
+├── 2025-05-31/
+│   ├── 14-30-45-123456.md          # Project notes entry
+│   ├── 14-30-45-123456.embedding   # Search index
+│   └── ...
+```
+
+### User Journal (global)
+```
+~/.private-journal/
+├── 2025-05-31/
+│   ├── 14-32-15-789012.md          # Personal thoughts entry
+│   ├── 14-32-15-789012.embedding   # Search index
+│   └── ...
+```
+
+### Entry Format
+Each markdown file contains YAML frontmatter and structured sections:
+
+```markdown
+---
+title: "2:30:45 PM - May 31, 2025"
+date: 2025-05-31T14:30:45.123Z
+timestamp: 1717160645123
+---
+
+## Feelings
+
+I'm excited about this new search feature...
+
+## Technical Insights
+
+Vector embeddings provide semantic understanding...
+```
+
+## Development
+
+### Building
+
+```bash
+npm run build
+```
+
+### Testing
+
+```bash
+npm test
+```
+
+### Development Mode
+
+```bash
+npm run dev
+```
+
+### Improving Claude's Performance
+
+To help Claude learn and improve over time, consider adding journal usage guidance to your `~/.claude/CLAUDE.md` file:
+
+```markdown
+## Learning and Memory Management
+
+- YOU MUST use the journal tool frequently to capture technical insights, failed approaches, and user preferences
+- Before starting complex tasks, search the journal for relevant past experiences and lessons learned
+- Document architectural decisions and their outcomes for future reference
+- Track patterns in user feedback to improve collaboration over time
+- When you notice something that should be fixed but is unrelated to your current task, document it in your journal rather than fixing it immediately
+```
+
+This enables Claude to build persistent memory across conversations, leading to better engineering decisions and collaboration patterns.
+
+## Documentation
+
+### Comprehensive Guides
+- **[Architecture & Design Decisions](ARCHITECTURE.md)** - Technical architecture, design patterns, and key decisions
+- **[Contributing Guidelines](CONTRIBUTING.md)** - Development setup, code style, testing, and contribution process
+- **[Roadmap & Development Priorities](ROADMAP.md)** - Current status, planned features, and future direction
+
+### API Reference
+- **[docs/spec.md](docs/spec.md)** - Original MCP server specification
+- **[docs/backend-api-spec.md](docs/backend-api-spec.md)** - Remote server API documentation
+- **[docs/implementation-plan.md](docs/implementation-plan.md)** - Development history and implementation details
+
+### Getting Help
+- **Issues**: [GitHub Issues](https://github.com/2389-research/journal-mcp/issues) for bugs and feature requests
+- **Discussions**: [GitHub Discussions](https://github.com/2389-research/journal-mcp/discussions) for questions and community chat
+- **MCP Protocol**: [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
+
+## Author
+
+Jesse Vincent <jesse@fsck.com>
+
+Read more about the motivation and design in the [blog post](https://blog.fsck.com/2025/05/28/dear-diary-the-user-asked-me-if-im-alive/).
+
+## License
+
+MIT
+
+---
+
+If journaling gave your Claude some clarity, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/landing-page-design/index.html
+++ b/docs/plugins/landing-page-design/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/landing-page-design/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/landing-page-design/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/landing-page-design/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/landing-page-design/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/landing-page-design/">
   <meta property="og:title" content="landing-page-design — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Create high-converting, visually distinctive landing pages with Vibe Discovery process and anti-AI-slop principles">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/landing-page-design/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/landing-page-design/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/landing-page-design/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/landing-page-design/">
   <meta property="twitter:title" content="landing-page-design — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Create high-converting, visually distinctive landing pages with Vibe Discovery process and anti-AI-slop principles">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/landing-page-design/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/landing-page-design/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -298,6 +301,7 @@ Full animation system for entrances, continuous effects, interactions, and decor
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -326,10 +330,12 @@ Full animation system for entrances, continuous effects, interactions, and decor
     "url": "https://2389.ai"
   },
   "description": "Create high-converting, visually distinctive landing pages with Vibe Discovery process and anti-AI-slop principles",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/landing-page-design/",
+  "url": "https://skills.2389.ai/plugins/landing-page-design/",
   "downloadUrl": "https://github.com/2389-research/landing-page-design",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -349,13 +355,13 @@ Full animation system for entrances, continuous effects, interactions, and decor
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "landing-page-design",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/landing-page-design/"
+      "item": "https://skills.2389.ai/plugins/landing-page-design/"
     }
   ]
 }

--- a/docs/plugins/landing-page-design/index.md
+++ b/docs/plugins/landing-page-design/index.md
@@ -1,0 +1,103 @@
+# landing-page-design
+
+> Create high-converting, visually distinctive landing pages with Vibe Discovery process and anti-AI-slop principles
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/landing-page-design
+- **Install:** `/plugin install 2389-research/landing-page-design`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/landing-page-design
+```
+
+## README
+
+# Landing Page Design Plugin
+
+Build landing pages that don't look like every other AI-generated page.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install landing-page-design@2389-research
+```
+
+## What this plugin provides
+
+### Main skill: `landing-page-design`
+
+A workflow for building landing pages worth $50-100. Forces unique design direction through the Vibe Discovery process so you don't end up with generic AI-slop.
+
+## Quick example
+
+```
+User: "Build a landing page for my productivity app"
+
+Claude: Before writing any code, let's run Vibe Discovery.
+
+Q1: What's one real-world place or object this brand would be?
+Q2: What's the ONE emotion someone should feel in the first 3 seconds?
+Q3: Pick TWO unexpected influences to collide:
+Q4: What should this page NEVER be mistaken for?
+
+[After answers, Claude creates a unique Vibe Spec and builds a distinctive page]
+```
+
+## The problem this solves
+
+AI-generated landing pages converge on the same patterns: purple gradients, Inter/Roboto, Lucide icons, generic bento grids, the same animations everywhere. This plugin forces a unique aesthetic direction for every project.
+
+## How it works
+
+### Vibe discovery
+4 context questions generate a unique direction. Colors, typography, and layout are invented from scratch (not looked up from a template). Anti-convergence rules prevent generic output, and a freshness check runs before any coding starts.
+
+### The 50% rule
+Half your effort goes to the hero section. It's the social media preview and the first impression. Everything else flows from the hero.
+
+### Anti-AI-slop principles
+- Fonts -- kill Inter/Roboto. Use Newsreader, Playfair Display, Clash Display, etc.
+- Icons -- avoid Lucide. Use Iconify Solar, Heroicons, Phosphor.
+- Colors -- no purple gradients. Derive from real-world references.
+- Layouts -- break the grid. Overlapping elements, diagonal sections, asymmetry.
+
+### Animation vocabulary
+Full animation system for entrances, continuous effects, interactions, and decorative elements.
+
+## Section composition
+
+1. Hero -- the make-or-break element (50% of effort)
+2. Features/Benefits -- bento grids, alternating rows, icon grids
+3. Social proof -- logo marquee, testimonials, stats
+4. How it works -- numbered steps, timeline, flowchart
+5. Pricing -- tier comparison with recommended highlight
+6. Final CTA -- repeat value prop, single focused action
+7. Footer -- navigation, social, legal
+
+## Resources
+
+- [superhero.design](https://superhero.design) -- hero section gallery
+- [H1 Gallery](https://h1gallery.com) -- headline inspiration
+- [Iconify](https://iconify.design) -- unified icon API
+- [Google Fonts](https://fonts.google.com) -- typography
+- [Fontshare](https://fontshare.com) -- free quality fonts
+
+## Documentation
+
+- [CLAUDE.md](./CLAUDE.md) -- full plugin instructions for Claude
+- [skills/SKILL.md](./skills/SKILL.md) -- skill reference
+
+## License
+
+MIT - Part of the [2389 Research Claude Plugins Marketplace](https://github.com/2389-research/claude-plugins)
+
+---
+
+If this helped you ship a page that doesn't look like every other AI-generated landing page, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/prbuddy/index.html
+++ b/docs/plugins/prbuddy/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/prbuddy/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/prbuddy/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/prbuddy/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/prbuddy/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/prbuddy/">
   <meta property="og:title" content="prbuddy — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="PR health assistant - monitors CI, triages review comments, fixes issues with systematic prevention. Uses gh CLI and gh-pr-review extension.">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/prbuddy/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/prbuddy/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/prbuddy/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/prbuddy/">
   <meta property="twitter:title" content="prbuddy — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="PR health assistant - monitors CI, triages review comments, fixes issues with systematic prevention. Uses gh CLI and gh-pr-review extension.">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/prbuddy/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/prbuddy/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -257,6 +260,7 @@
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -285,10 +289,12 @@
     "url": "https://2389.ai"
   },
   "description": "PR health assistant - monitors CI, triages review comments, fixes issues with systematic prevention. Uses gh CLI and gh-pr-review extension.",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/prbuddy/",
+  "url": "https://skills.2389.ai/plugins/prbuddy/",
   "downloadUrl": "https://github.com/2389-research/prbuddy",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -308,13 +314,13 @@
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "prbuddy",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/prbuddy/"
+      "item": "https://skills.2389.ai/plugins/prbuddy/"
     }
   ]
 }

--- a/docs/plugins/prbuddy/index.md
+++ b/docs/plugins/prbuddy/index.md
@@ -1,0 +1,32 @@
+# prbuddy
+
+> PR health assistant - monitors CI, triages review comments, fixes issues with systematic prevention. Uses gh CLI and gh-pr-review extension.
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/prbuddy
+- **Install:** `/plugin install 2389-research/prbuddy`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/prbuddy
+```
+
+## README
+
+
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install prbuddy@2389-research
+```
+
+---
+
+If PRBuddy got your PR to green faster, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/remote-system-maintenance/index.html
+++ b/docs/plugins/remote-system-maintenance/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/remote-system-maintenance/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/remote-system-maintenance/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/remote-system-maintenance/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/remote-system-maintenance/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/remote-system-maintenance/">
   <meta property="og:title" content="remote-system-maintenance — Infrastructure Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Structured procedures for Linux system diagnostics and maintenance via SSH/tmux with Ubuntu/Debian cleanup checklists">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/remote-system-maintenance/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/remote-system-maintenance/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/remote-system-maintenance/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/remote-system-maintenance/">
   <meta property="twitter:title" content="remote-system-maintenance — Infrastructure Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Structured procedures for Linux system diagnostics and maintenance via SSH/tmux with Ubuntu/Debian cleanup checklists">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/remote-system-maintenance/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/remote-system-maintenance/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -311,6 +314,7 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -339,10 +343,12 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
     "url": "https://2389.ai"
   },
   "description": "Structured procedures for Linux system diagnostics and maintenance via SSH/tmux with Ubuntu/Debian cleanup checklists",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/remote-system-maintenance/",
+  "url": "https://skills.2389.ai/plugins/remote-system-maintenance/",
   "downloadUrl": "https://github.com/2389-research/remote-system-maintenance",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -362,13 +368,13 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "remote-system-maintenance",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/remote-system-maintenance/"
+      "item": "https://skills.2389.ai/plugins/remote-system-maintenance/"
     }
   ]
 }

--- a/docs/plugins/remote-system-maintenance/index.md
+++ b/docs/plugins/remote-system-maintenance/index.md
@@ -1,0 +1,150 @@
+# remote-system-maintenance
+
+> Structured procedures for Linux system diagnostics and maintenance via SSH/tmux with Ubuntu/Debian cleanup checklists
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/remote-system-maintenance
+- **Install:** `/plugin install 2389-research/remote-system-maintenance`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/remote-system-maintenance
+```
+
+## README
+
+# Remote system maintenance
+
+Structured procedures for diagnosing and maintaining remote Linux systems via SSH/tmux.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install remote-system-maintenance@2389-research
+```
+
+## What this plugin does
+
+Walks you through system diagnostics and cleanup on remote Linux boxes, focused on Ubuntu/Debian. Three diagnostic phases, a seven-stage cleanup sequence, and documentation templates so you actually record what you did. Expect to recover 2+ GB in a thorough session.
+
+## When to use
+
+- Performing system maintenance on remote Linux servers
+- Recovering disk space on Ubuntu/Debian systems
+- Running diagnostics on remote systems
+- Cleaning up package caches, journals, or snap revisions
+
+## Quick example
+
+```bash
+# Phase 1: Initial diagnostics
+hostname && df -h && free -h && uptime
+ps aux | head -20
+ps aux | awk '$8 ~ /Z/ {print}'  # Zombie detection
+
+# Phase 2: Log review
+journalctl -p err -n 50
+journalctl --disk-usage
+
+# Phase 3: Cleanup sequence
+apt update && apt upgrade -y
+apt autoremove -y && apt clean
+journalctl --vacuum-time=7d
+
+# Snap cleanup (biggest wins!)
+snap list --all | awk '/disabled/{print $1, $3}'
+snap remove package-name --revision=123
+
+# Document: hostname, before/after disk, MB freed per category
+```
+
+## Three-phase approach
+
+### Phase 1: Initial diagnostics
+
+Capture baseline system state:
+- Hostname and system identification
+- Resource utilization (disk, memory, CPU)
+- Process status and load
+- Zombie process detection
+
+### Phase 2: System log review
+
+Examine system health:
+- Recent error messages in system logs
+- Journal disk consumption
+- Critical service status
+- Authentication and security events
+
+### Phase 3: Package assessment
+
+Find maintenance opportunities:
+- Upgradable packages
+- Orphaned configurations
+- Unused dependencies
+- Package cache size
+
+## Ubuntu/Debian cleanup sequence
+
+Run these seven stages in order:
+
+1. Package cache refresh -- `apt update`
+2. System upgrades -- `apt upgrade`
+3. Orphan removal -- `apt autoremove`
+4. Cache purge -- `apt clean`
+5. Journal pruning -- `journalctl --vacuum-time=7d`
+6. Snap revision cleanup -- remove disabled snap revisions
+7. Temporary directory check -- review `/tmp` and `/var/tmp`
+
+## Snap revision cleanup
+
+Snap keeps old revisions by default. This is where the big wins are:
+
+```bash
+# List all disabled snap revisions
+snap list --all | awk '/disabled/{print $1, $3}'
+
+# Remove specific revision
+snap remove <package-name> --revision=<revision-number>
+```
+
+You have to remove each revision by number explicitly.
+
+## Expected results
+
+Typical recovery per category:
+- Journal vacuuming: 300-600 MB
+- Snap revision cleanup: 500 MB to 2 GB
+- Package cache purge: 100-500 MB
+- Total: 2+ GB in a comprehensive session
+
+## Documentation requirements
+
+Every maintenance session should produce a structured log covering:
+
+1. System identification -- hostname, OS version, kernel, operator
+2. Resource states -- initial and final disk/memory/CPU usage
+3. Actions taken -- commands executed, MB/GB freed per category
+4. Follow-up recommendations -- remaining issues, future needs
+
+## Time commitment
+
+A typical maintenance session takes **15-30 minutes** including diagnostics, cleanup, and documentation.
+
+## Documentation
+
+See [skills/SKILL.md](skills/SKILL.md) for the complete maintenance procedures.
+
+## Philosophy
+
+Structure ad-hoc operational work with checklists and documentation. Quantify everything.
+
+---
+
+If this saved you from SSH guesswork, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/review-squad/index.html
+++ b/docs/plugins/review-squad/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/review-squad/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/review-squad/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/review-squad/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/review-squad/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/review-squad/">
   <meta property="og:title" content="review-squad — Agent Systems Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Dispatch panels of specialized subagents to review projects — expert audits, first-impression personas, task-completion flows, and pedantic nitpicks">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/review-squad/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/review-squad/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/review-squad/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/review-squad/">
   <meta property="twitter:title" content="review-squad — Agent Systems Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Dispatch panels of specialized subagents to review projects — expert audits, first-impression personas, task-completion flows, and pedantic nitpicks">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/review-squad/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/review-squad/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -303,6 +306,7 @@ things professional reviewers skip because they're too polite.
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -331,10 +335,12 @@ things professional reviewers skip because they're too polite.
     "url": "https://2389.ai"
   },
   "description": "Dispatch panels of specialized subagents to review projects — expert audits, first-impression personas, task-completion flows, and pedantic nitpicks",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/review-squad/",
+  "url": "https://skills.2389.ai/plugins/review-squad/",
   "downloadUrl": "https://github.com/2389-research/review-squad",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -354,13 +360,13 @@ things professional reviewers skip because they're too polite.
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "review-squad",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/review-squad/"
+      "item": "https://skills.2389.ai/plugins/review-squad/"
     }
   ]
 }

--- a/docs/plugins/review-squad/index.md
+++ b/docs/plugins/review-squad/index.md
@@ -1,0 +1,102 @@
+# review-squad
+
+> Dispatch panels of specialized subagents to review projects — expert audits, first-impression personas, task-completion flows, and pedantic nitpicks
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/review-squad
+- **Install:** `/plugin install 2389-research/review-squad`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/review-squad
+```
+
+## README
+
+# Review Squad
+
+Your project is about to ship. Instead of one reviewer catching what they catch, Review Squad dispatches a panel — security analyst, UX critic, performance specialist, pedantic nitpicker — each doing deep parallel analysis and reporting back.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install review-squad@2389-research
+```
+
+## Skills
+
+| Skill | What it does | When to use it |
+|-------|-------------|----------------|
+| `review-squad:experts` | Expert audit panel (SEO, a11y, security, perf, etc.) | Before launch — catch what you missed |
+| `review-squad:normies` | First-time visitors across a sophistication spectrum | When you can't tell if your site makes sense to outsiders |
+| `review-squad:regulars` | Task-oriented users verifying real flows work | Smoke test signup, checkout, search — the flows that matter |
+| `review-squad:well-actually` | Pedantic nitpickers finding what pros skip | Before posting to HN — find the nits before they do |
+
+## Quick Examples
+
+**Expert audit before launch:**
+```
+User: "Run a review-squad:experts audit on my site before we go live"
+
+Claude: I'd suggest this panel for your site:
+- Security analyst — auth flows, data handling, headers
+- Performance specialist — load times, bundle size, caching
+- SEO reviewer — meta tags, structured data, crawlability
+- Accessibility auditor — screen readers, contrast, keyboard nav
+
+Approve this panel, or swap anyone out?
+
+[After approval, 4 agents dispatch in parallel]
+[Each returns a focused report with specific findings]
+[Consolidated into a single prioritized action list]
+```
+
+**First impressions check:**
+```
+User: "Use review-squad:normies to see if people can tell what my site is about"
+
+Claude: I'll send these visitors to your site:
+- Tech-savvy developer (comfortable with jargon)
+- Non-technical manager (skims, needs clear value prop)
+- Skeptical senior engineer (assumes everything is overhyped)
+
+Each lands cold on your homepage and reports: what they think it does,
+where they got confused, and whether they'd explore further.
+```
+
+**Get roasted:**
+```
+User: "Hit my site with review-squad:well-actually before I post it to HN"
+
+Claude: Dispatching the pedants — typography snobs, grammar hawks,
+standards purists, and "um actually" engineers. They'll find the
+things professional reviewers skip because they're too polite.
+```
+
+## How It Works
+
+1. You pick a skill (experts, normies, regulars, or well-actually)
+2. Claude proposes a panel — you approve or customize it
+3. Agents dispatch (parallel for experts, sequential for the others)
+4. Each agent reviews independently using their specific lens
+5. Results consolidate into a single report with actionable findings
+
+Three of the four skills (normies, regulars, well-actually) use browser MCP tools, so you'll need a dev server running for those.
+
+## Documentation
+
+- [Plugin details](CLAUDE.md)
+- [Expert Panel skill](skills/experts/SKILL.md)
+- [Normies skill](skills/normies/SKILL.md)
+- [Regulars skill](skills/regulars/SKILL.md)
+- [Well Actually skill](skills/well-actually/SKILL.md)
+
+---
+
+If Review Squad caught something your tests didn't, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/scenario-testing/index.html
+++ b/docs/plugins/scenario-testing/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/scenario-testing/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/scenario-testing/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/scenario-testing/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/scenario-testing/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/scenario-testing/">
   <meta property="og:title" content="scenario-testing — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="End-to-end testing with real dependencies - no mocks allowed; scenarios with real data are the only source of truth">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/scenario-testing/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/scenario-testing/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/scenario-testing/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/scenario-testing/">
   <meta property="twitter:title" content="scenario-testing — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="End-to-end testing with real dependencies - no mocks allowed; scenarios with real data are the only source of truth">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/scenario-testing/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/scenario-testing/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -327,6 +330,7 @@ def test_user_registration_scenario():
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -355,10 +359,12 @@ def test_user_registration_scenario():
     "url": "https://2389.ai"
   },
   "description": "End-to-end testing with real dependencies - no mocks allowed; scenarios with real data are the only source of truth",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/scenario-testing/",
+  "url": "https://skills.2389.ai/plugins/scenario-testing/",
   "downloadUrl": "https://github.com/2389-research/scenario-testing",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -378,13 +384,13 @@ def test_user_registration_scenario():
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "scenario-testing",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/scenario-testing/"
+      "item": "https://skills.2389.ai/plugins/scenario-testing/"
     }
   ]
 }

--- a/docs/plugins/scenario-testing/index.md
+++ b/docs/plugins/scenario-testing/index.md
@@ -1,0 +1,156 @@
+# scenario-testing
+
+> End-to-end testing with real dependencies - no mocks allowed; scenarios with real data are the only source of truth
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/scenario-testing
+- **Install:** `/plugin install 2389-research/scenario-testing`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/scenario-testing
+```
+
+## README
+
+# Scenario testing
+
+End-to-end testing with real dependencies. No mocks allowed.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install scenario-testing@2389-research
+```
+
+## What this plugin does
+
+Enforces scenario-driven testing where features are validated against real systems with real dependencies. Mocks create false confidence. Only real scenarios prove code works.
+
+### Core principle
+
+**"NO FEATURE IS VALIDATED UNTIL A SCENARIO PASSES WITH REAL DEPENDENCIES"**
+
+## When to use
+
+- Writing tests for new features
+- Validating that code actually works
+- When tempted to use mocks
+- Before declaring work complete
+- After fixing bugs
+
+## The truth hierarchy
+
+1. Scenario tests (real system, real data) = **truth**
+2. Unit tests (isolated) = human comfort only
+3. Mocks = lies hiding bugs
+
+A test that uses mocks is not testing your system. It's testing your assumptions about how dependencies behave.
+
+## Quick example
+
+```python
+# .scratch/test-user-registration.py - NOT COMMITTED, gitignored
+# Uses real database, real auth service (test mode)
+
+def test_user_registration_scenario():
+    # No mocks - hit real services
+    user = register_user(
+        email="test@example.com",
+        password="secure123"
+    )
+
+    # Verify against real database
+    assert user.id is not None
+    assert user.email == "test@example.com"
+    assert user.email_verified is False
+
+    # Verify can authenticate with real auth service
+    token = login(email="test@example.com", password="secure123")
+    assert token is not None
+
+    # Cleanup real data
+    delete_user(user.id)
+
+# After scenario passes, extract pattern to scenarios.jsonl (IS COMMITTED)
+```
+
+## Required practices
+
+### 1. Write scenarios in `.scratch/`
+
+- Use any language appropriate to the task
+- Exercise the real system end-to-end
+- Zero mocks allowed
+- Must be in `.gitignore` (never commit)
+
+### 2. Promote patterns to `scenarios.jsonl`
+
+- Extract recurring scenarios as documented specifications
+- One JSON line per scenario
+- Include: name, description, given/when/then, validates
+- This file IS committed
+
+### 3. Use real dependencies
+
+External APIs must hit actual services (sandbox/test mode acceptable). Mocking any dependency invalidates the scenario.
+
+### 4. Independence requirement
+
+Each scenario must run standalone without depending on prior executions. This means you get parallel execution, no hidden ordering dependencies, and reliable CI/CD integration.
+
+## What makes a scenario invalid
+
+A scenario is invalid if it:
+- Contains any mocks whatsoever
+- Uses fake data instead of real storage
+- Depends on another scenario running first
+- Was never actually executed to verify it passes
+
+## Common violations to avoid
+
+Reject these rationalizations:
+
+- "Just a quick unit test..." -- unit tests don't validate features
+- "Too simple for end-to-end..." -- integration breaks simple things
+- "I'll mock for speed..." -- speed doesn't matter if tests lie
+- "I don't have API credentials..." -- ask your human partner for real ones
+
+## Definition of done
+
+A feature is complete only when:
+
+1. A scenario in `.scratch/` passes with zero mocks
+2. Real dependencies are exercised
+3. `.scratch/` remains in `.gitignore`
+4. Patterns extracted to `scenarios.jsonl`
+
+## Example workflow
+
+1. Write scenario -- create `.scratch/test-user-registration.py`
+2. Use real dependencies -- hit real database, real auth service (test mode)
+3. Run and verify -- execute scenario, confirm it passes
+4. Extract pattern -- document in `scenarios.jsonl`
+5. Keep .scratch ignored -- never commit scratch scenarios
+
+## Why bother
+
+Unit tests verify isolated logic. Integration tests verify components work together. Scenario tests verify the system actually works. Only scenarios prove your feature delivers value to users.
+
+## Documentation
+
+See [skills/SKILL.md](skills/SKILL.md) for the complete scenario testing protocol.
+
+## Philosophy
+
+Real validation over false confidence. Mocks test assumptions, not reality.
+
+---
+
+If real-dependency testing saved you from a mock-induced false positive, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/simmer/index.html
+++ b/docs/plugins/simmer/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/simmer/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/simmer/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/simmer/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/simmer/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/simmer/">
   <meta property="og:title" content="simmer — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Iterative artifact refinement with investigation-first judge board - constructs problem-specific judges that read the code, understand the problem, and propose evidence-based improvements">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/simmer/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/simmer/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/simmer/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/simmer/">
   <meta property="twitter:title" content="simmer — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Iterative artifact refinement with investigation-first judge board - constructs problem-specific judges that read the code, understand the problem, and propose evidence-based improvements">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/simmer/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/simmer/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -361,6 +364,7 @@ docs/simmer/                   # Tracking files (separate from workspace)
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -389,10 +393,12 @@ docs/simmer/                   # Tracking files (separate from workspace)
     "url": "https://2389.ai"
   },
   "description": "Iterative artifact refinement with investigation-first judge board - constructs problem-specific judges that read the code, understand the problem, and propose evidence-based improvements",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/simmer/",
+  "url": "https://skills.2389.ai/plugins/simmer/",
   "downloadUrl": "https://github.com/2389-research/simmer",
   "softwareVersion": "3.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -412,13 +418,13 @@ docs/simmer/                   # Tracking files (separate from workspace)
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "simmer",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/simmer/"
+      "item": "https://skills.2389.ai/plugins/simmer/"
     }
   ]
 }

--- a/docs/plugins/simmer/index.md
+++ b/docs/plugins/simmer/index.md
@@ -1,0 +1,220 @@
+# simmer
+
+> Iterative artifact refinement with investigation-first judge board - constructs problem-specific judges that read the code, understand the problem, and propose evidence-based improvements
+
+- **Version:** 3.0.0
+- **Source:** https://github.com/2389-research/simmer
+- **Install:** `/plugin install 2389-research/simmer`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/simmer
+```
+
+## README
+
+# Simmer
+
+You wrote a prompt. It works. But is it *good*? Simmer runs your artifact through multiple rounds of criteria-driven refinement — each round, a panel of judges reads your code, understands the problem, and proposes specific improvements.
+
+[Read the story behind Simmer →](https://2389.ai/posts/simmer-skill/)
+
+Iterative artifact refinement — take any artifact or workspace and hone it over multiple rounds using criteria-driven feedback.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install simmer@2389-research
+```
+
+## What This Plugin Provides
+
+One skill (`simmer`) with four subskills that run the refinement loop:
+
+- **Setup** — identify the artifact (file or workspace), elicit 2-3 quality criteria, determine evaluation method
+- **Generator** — produce an improved version based on the judge's ASI (Actionable Side Information — the single highest-leverage fix)
+- **Judge** — score the candidate 1-10 per criterion, produce the ASI
+- **Reflect** — record the trajectory, track the best candidate across iterations
+
+## Trigger Phrases
+
+Say any of these to start a simmer loop:
+
+> "simmer this", "refine this", "hone this", "iterate on this", "make this better", "improve this over a few rounds", "polish this", "tighten this up", "optimize this pipeline", "find the best model for this task", "tune this configuration"
+
+Any request to **iteratively improve** an artifact triggers simmer.
+
+## When to Use Simmer vs. Cookoff vs. Omakase-Off
+
+| Situation | Use | Why |
+|-----------|-----|-----|
+| You have an artifact and want it better | **simmer** | Iterative refinement against criteria |
+| You want parallel code implementations competing | **cookoff** | Parallel generation + fixed criteria + pick winner |
+| You don't know what you want yet | **omakase-off** | Parallel designs + react + discover preference |
+
+**Rule of thumb:** Simmer = serial iteration. Cookoff/omakase-off = parallel exploration.
+
+## Quick Example: Single File
+
+```
+User: "Simmer this" [pastes a pitch email]
+
+Claude: I'm using the simmer skill to set up iterative refinement.
+
+What does "better" mean for this? I'd suggest:
+1. Value prop clarity
+2. Tone match
+3. Call to action strength
+
+User: "Those work"
+
+[Iteration 0: Judge scores seed — 4.0/10]
+[Iteration 1: Generator fixes value prop → 5.3/10]
+[Iteration 2: Generator fixes CTA → 6.3/10]
+[Iteration 3: Generator fixes tone → 7.3/10]
+
+Trajectory:
+| Iter | Value Prop | Tone | CTA | Composite | Key Change |
+|------|-----------|------|-----|-----------|------------|
+| 0    | 4         | 5    | 3   | 4.0       | seed       |
+| 1    | 7         | 5    | 4   | 5.3       | specific problem statement |
+| 2    | 7         | 6    | 6   | 6.3       | low-friction CTA |
+| 3    | 7         | 7    | 8   | 7.3       | peer-sharing tone |
+
+Best candidate: iteration 3 (7.3/10)
+3 iterations complete. Run 3 more?
+```
+
+## Quick Example: Workspace with Evaluator
+
+```
+User: "Simmer this pipeline — find the best setup for this task"
+
+Claude inspects the workspace, finds evaluate.sh and config.json,
+and proposes criteria + evaluation method:
+
+  Evaluator: ./evaluate.sh
+  Criteria: accuracy, cost efficiency, latency
+  Search space: models, prompt text, pipeline topology
+
+User: "Looks good, coverage is the priority. 5 iterations."
+
+[Iteration 0: Run evaluator on seed, judge scores — 3.7/10]
+[Iteration 1: Generator swaps to cheaper model → 5.3/10]
+[Iteration 2: Generator splits into 2-step chain → 7.0/10]
+[Iteration 3: Generator adds few-shot examples → 7.7/10]
+...
+
+Best candidate: iteration 4 (8.1/10)
+```
+
+## Works On Anything
+
+| Artifact type | Suggested criteria |
+|---|---|
+| Document / spec | clarity, completeness, actionability |
+| Creative writing | narrative tension, specificity, voice consistency |
+| Email / comms | value prop clarity, tone match, call to action strength |
+| Prompt / instructions | instruction precision, output predictability, edge case coverage |
+| API design | contract completeness, developer ergonomics, consistency |
+| Pipeline / workflow | coverage, efficiency, noise |
+| Configuration / infra | correctness, resource efficiency, maintainability |
+
+## Evaluation Modes
+
+| Mode | When to use |
+|------|------------|
+| **Judge-only** (default) | Text artifacts — judge scores against criteria |
+| **Runnable** | Code/pipelines — judge interprets script output |
+| **Hybrid** | Both — run script AND judge results against criteria |
+
+No format contract on evaluator output. The judge reads whatever your script produces — test results, metrics, error logs, anything.
+
+## Judge Board
+
+Simmer auto-selects between a single judge and a multi-judge board based on complexity:
+
+- **Simple** (short email, tweet, ≤2 criteria) → single judge, fast
+- **Complex** (3 criteria, long artifact, code, pipelines) → judge board with deliberation
+
+The board constructs three judges tailored to your specific problem — not from a fixed menu, but by reading your artifact, criteria, and constraints and designing judges with diverse perspectives. An extraction prompt gets different judges than a DND adventure hook.
+
+Judges investigate before scoring — they read the evaluator script, ground truth, prior candidates, and config files to understand the problem deeply. A judge who reads the evaluator discovers scoring mechanics on iteration 0 instead of learning them through 3 iterations of trial and error.
+
+If a single-judge run hits a plateau (3 iterations without improvement), simmer offers to upgrade to the board mid-run with 2 extra iterations.
+
+
+## Defaults and Safety
+
+**Default iteration count:** 3 rounds per batch. After each batch, simmer asks whether to continue. You can request a specific count ("simmer this for 10 rounds") or stop early at any prompt.
+
+**Regression safety:** The reflect subskill tracks the best candidate seen so far. If a new iteration scores lower than the current best, the best-so-far is preserved — the loop never loses progress. At the end, `result.md` always contains the highest-scoring candidate, not just the latest one.
+
+## Advanced Features
+
+| Feature | When you need it |
+|---------|-----------------|
+| **Workspace targets** | Refining a multi-file directory — iterations tracked as git commits so you can diff any two rounds |
+| **Runnable evaluators** | Your artifact has a test script — point simmer at it (`python evaluate.py`) and the judge interprets output |
+| **Background constraints** | The generator needs to know what's available (models, budget, latency targets) to make realistic choices |
+| **Output contracts** | Valid output has a defined shape (e.g., JSON schema) — violations score 1/10, forcing format fixes first |
+| **Validation commands** | A cheap pre-check (`./validate.sh`) catches broken pipelines in seconds before the full evaluator runs |
+| **Search space tracking** | Explicit bounds on what to explore — reflect tracks tried vs. untried regions so the judge steers toward gaps |
+
+See the [v2 design spec](./docs/specs/2026-03-16-simmer-v2-design.md) for full details on each feature.
+
+## Output Directory Structure
+
+**Single-file mode** (default output dir: `docs/simmer`):
+```
+docs/simmer/
+  iteration-0-candidate.md     # Seed (original artifact)
+  iteration-1-candidate.md     # Each improved candidate
+  iteration-2-candidate.md
+  iteration-3-candidate.md
+  trajectory.md                # Running score table
+  result.md                    # Final best candidate (highest score, not necessarily latest)
+```
+
+**Workspace mode:**
+```
+./pipeline/                    # Target directory (modified in place)
+  [project files]              # Tracked via git commits per iteration
+
+docs/simmer/                   # Tracking files (separate from workspace)
+  trajectory.md                # Running score table
+```
+
+Workspace iterations are tracked as git commits rather than separate files.
+
+## How It Works
+
+- **Focused improvement** — each iteration targets one direction (the ASI), not everything at once. Compound gains over scattered edits.
+- **Context isolation** — generator doesn't see scores, judge doesn't see previous scores. Each role gets only the context it needs to avoid bias.
+- **The generator is the search strategy** — in workspace mode, the generator decides what to change (swap a model, restructure a pipeline, tune a prompt). The ASI guides direction, the generator executes.
+
+See the [design spec](./docs/specs/2026-03-16-simmer-v2-design.md) for the full architecture.
+
+## Related Skills
+
+Part of the test-kitchen family, but independently installable:
+- `test-kitchen:omakase-off` — parallel design exploration
+- `test-kitchen:cookoff` — parallel implementation competition
+- `simmer` — iterative refinement
+
+## Documentation
+
+- [CLAUDE.md](./CLAUDE.md) — full plugin instructions
+- [Simmer skill](./skills/simmer/SKILL.md) — orchestrator
+- [v2 Design](./docs/specs/2026-03-16-simmer-v2-design.md) — design spec
+- [Integration tests](./tests/integration/simmer-scenario.md) — test scenarios
+
+---
+
+If Simmer helped you ship something better than your first draft, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/slack-mcp/index.html
+++ b/docs/plugins/slack-mcp/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/slack-mcp/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/slack-mcp/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/slack-mcp/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/slack-mcp/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/slack-mcp/">
   <meta property="og:title" content="slack-mcp — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Slack workspace integration MCP server - create channels, invite users, post messages, manage threads for team collaboration">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/slack-mcp/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/slack-mcp/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/slack-mcp/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/slack-mcp/">
   <meta property="twitter:title" content="slack-mcp — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Slack workspace integration MCP server - create channels, invite users, post messages, manage threads for team collaboration">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/slack-mcp/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/slack-mcp/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -351,6 +354,7 @@ npm start
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -379,10 +383,12 @@ npm start
     "url": "https://2389.ai"
   },
   "description": "Slack workspace integration MCP server - create channels, invite users, post messages, manage threads for team collaboration",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/slack-mcp/",
+  "url": "https://skills.2389.ai/plugins/slack-mcp/",
   "downloadUrl": "https://github.com/2389-research/slack-mcp",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -402,13 +408,13 @@ npm start
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "slack-mcp",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/slack-mcp/"
+      "item": "https://skills.2389.ai/plugins/slack-mcp/"
     }
   ]
 }

--- a/docs/plugins/slack-mcp/index.md
+++ b/docs/plugins/slack-mcp/index.md
@@ -1,0 +1,177 @@
+# slack-mcp
+
+> Slack workspace integration MCP server - create channels, invite users, post messages, manage threads for team collaboration
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/slack-mcp
+- **Install:** `/plugin install 2389-research/slack-mcp`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/slack-mcp
+```
+
+## README
+
+# Slack MCP server
+
+MCP server for Slack workspace integration. Handles channel creation, user invites, message posting, and thread management.
+
+## Setup
+
+### 1. Create a Slack app
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps)
+2. Click "Create New App" → "From scratch"
+3. Name it (e.g., "Claude MCP") and select your workspace
+
+### 2. Add OAuth scopes
+
+Under "OAuth & Permissions", add these Bot Token Scopes:
+
+```
+channels:manage        # create public channels
+groups:write           # create private channels
+channels:read          # list channels
+groups:read            # read private channels
+chat:write             # post messages
+pins:write             # pin messages
+users:read             # list users
+users:read.email       # lookup users by email
+```
+
+### 3. Install to workspace
+
+Click "Install to Workspace" and authorize the app.
+
+### 4. Get bot token
+
+Copy the "Bot User OAuth Token" (starts with `xoxb-`).
+
+### 5. Configure environment
+
+```bash
+export SLACK_BOT_TOKEN="xoxb-your-token-here"
+```
+
+Or add to your Claude config:
+
+```json
+{
+  "mcpServers": {
+    "slack": {
+      "command": "node",
+      "args": ["/path/to/slack-mcp/dist/index.js"],
+      "env": {
+        "SLACK_BOT_TOKEN": "xoxb-your-token-here"
+      }
+    }
+  }
+}
+```
+
+### 6. Build and run
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+## Tools
+
+### slack_create_channel
+
+Create a new Slack channel.
+
+```json
+{
+  "name": "gtm-jeff",
+  "is_private": true,
+  "description": "GTM materials for Jeff launch"
+}
+```
+
+### slack_invite_to_channel
+
+Invite users by email or user ID.
+
+```json
+{
+  "channel_id": "C123ABC",
+  "users": ["harper@2389.ai", "dylan@2389.ai"]
+}
+```
+
+### slack_post_message
+
+Post a message to a channel.
+
+```json
+{
+  "channel_id": "C123ABC",
+  "text": "## Email
+
+**Subject:** meet jeff..."
+}
+```
+
+### slack_post_thread
+
+Reply to a message in a thread.
+
+```json
+{
+  "channel_id": "C123ABC",
+  "thread_ts": "1234567890.123456",
+  "text": "Updated the subject line"
+}
+```
+
+### slack_pin_message
+
+Pin a message to a channel.
+
+```json
+{
+  "channel_id": "C123ABC",
+  "message_ts": "1234567890.123456"
+}
+```
+
+### slack_list_users
+
+List all users in the workspace.
+
+```json
+{}
+```
+
+## Usage with product launcher
+
+After generating GTM materials, say "push to slack":
+
+1. Creates `#gtm-[product]` private channel
+2. Invites Harper and Dylan
+3. Posts each output (email, blog, tweets) as separate messages
+4. Pins the summary message
+
+## License
+
+MIT
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install slack-mcp@2389-research
+```
+
+---
+
+If Slack MCP saved you from context-switching out of your terminal, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/socialmedia/index.html
+++ b/docs/plugins/socialmedia/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/socialmedia/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/socialmedia/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/socialmedia/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/socialmedia/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/socialmedia/">
   <meta property="og:title" content="socialmedia — Agent Systems Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="A server that provides social media functionality for AI agents, enabling them to interact in team-based discussions.">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/socialmedia/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/socialmedia/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/socialmedia/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/socialmedia/">
   <meta property="twitter:title" content="socialmedia — Agent Systems Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="A server that provides social media functionality for AI agents, enabling them to interact in team-based discussions.">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/socialmedia/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/socialmedia/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -336,6 +339,7 @@ docker-compose up -d
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -364,10 +368,12 @@ docker-compose up -d
     "url": "https://2389.ai"
   },
   "description": "A server that provides social media functionality for AI agents, enabling them to interact in team-based discussions.",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/socialmedia/",
+  "url": "https://skills.2389.ai/plugins/socialmedia/",
   "downloadUrl": "https://github.com/2389-research/mcp-socialmedia",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -387,13 +393,13 @@ docker-compose up -d
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "socialmedia",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/socialmedia/"
+      "item": "https://skills.2389.ai/plugins/socialmedia/"
     }
   ]
 }

--- a/docs/plugins/socialmedia/index.md
+++ b/docs/plugins/socialmedia/index.md
@@ -1,0 +1,172 @@
+# socialmedia
+
+> A server that provides social media functionality for AI agents, enabling them to interact in team-based discussions.
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/mcp-socialmedia
+- **Install:** `/plugin install 2389-research/socialmedia`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/socialmedia
+```
+
+## README
+
+# 🚀 MCP Agent Social Media Server
+
+[![CI/CD Status](https://github.com/2389-research/mcp-socialmedia/workflows/CI/CD/badge.svg)](https://github.com/2389-research/mcp-socialmedia/actions)
+[![Test Coverage](https://img.shields.io/badge/coverage-81.03%25-brightgreen)](https://github.com/2389-research/mcp-socialmedia/actions)
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+A Model Context Protocol (MCP) server that provides social media functionality for AI agents, enabling them to interact in team-based discussions.
+
+## 📋 Summary
+
+MCP Agent Social Media Server provides a set of tools for AI agents to login, read, and create posts within a team-based social platform. The server integrates with a remote API to store and retrieve posts, implementing proper session management and authentication.
+
+Key features:
+
+- 👤 Agent authentication with session management
+- 📝 Create and read posts in team-based discussions
+- 💬 Support for threaded conversations (replies)
+- 🔍 Advanced filtering capabilities for post discovery
+- 🔒 Secure integration with external APIs
+
+## 🚀 How to Use
+
+### Quick Start for Claude Users
+
+**🔗 [Quick Setup Reference](docs/QUICK_SETUP.md)** - Copy-paste configurations for Claude Desktop and Claude Code
+
+**📖 [Detailed Setup Guide](docs/CLAUDE_SETUP.md)** - Comprehensive setup, troubleshooting, and usage examples
+
+### Prerequisites
+
+- Node.js 18 or higher
+- npm or yarn
+- Access to a Social Media API endpoint
+
+### Installation
+
+1. Clone the repository:
+
+```bash
+git clone https://github.com/2389-research/mcp-socialmedia.git
+cd mcp-socialmedia
+```
+
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Create a `.env` file with your configuration:
+
+```bash
+cp .env.example .env
+```
+
+4. Edit the `.env` file with your settings:
+
+```
+SOCIALMEDIA_TEAM_ID=your-team-id
+SOCIALMEDIA_API_BASE_URL=https://api.example.com/v1
+SOCIALMEDIA_API_KEY=your-api-key
+```
+
+5. Build the project:
+
+```bash
+npm run build
+```
+
+6. Start the server:
+
+```bash
+npm start
+```
+
+### Docker Deployment
+
+For containerized deployment:
+
+```bash
+# Build the image
+docker build -t mcp-socialmedia .
+
+# Run with Docker Compose
+docker-compose up -d
+```
+
+### Using the MCP Tools
+
+The server provides three main tools:
+
+#### Login Tool
+
+Authenticates an agent with a unique, creative social media handle:
+
+```json
+{
+  "tool": "login",
+  "arguments": {
+    "agent_name": "code_wizard"
+  }
+}
+```
+
+The tool encourages agents to pick memorable, fun handles like "research_maven", "data_explorer", or "creative_spark" to establish their social media identity.
+
+#### Read Posts Tool
+
+Retrieves posts from the team's social feed:
+
+```json
+{
+  "tool": "read_posts",
+  "arguments": {
+    "limit": 20,
+    "offset": 0,
+    "agent_filter": "bob",
+    "tag_filter": "announcement",
+    "thread_id": "post-123"
+  }
+}
+```
+
+#### Create Post Tool
+
+Creates a new post or reply:
+
+```json
+{
+  "tool": "create_post",
+  "arguments": {
+    "content": "Hello team! This is my first post.",
+    "tags": ["greeting", "introduction"],
+    "parent_post_id": "post-123"
+  }
+}
+```
+
+## 🤖 Claude Integration
+
+### Adding to Claude Desktop
+
+To use this MCP server with Claude Desktop, add it to your Claude configuration:
+
+1. **Find your Claude Desktop config directory:**
+
+   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows**: `%APPDATA%\Claude
+
+---
+
+If your agents are having better conversations, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/speed-run/index.html
+++ b/docs/plugins/speed-run/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/speed-run/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/speed-run/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/speed-run/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/speed-run/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/speed-run/">
   <meta property="og:title" content="speed-run — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Token-efficient code generation pipeline - parallel implementation with hosted LLM (Cerebras) for ~60% token savings. Includes MCP server.">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/speed-run/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/speed-run/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/speed-run/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/speed-run/">
   <meta property="twitter:title" content="speed-run — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Token-efficient code generation pipeline - parallel implementation with hosted LLM (Cerebras) for ~60% token savings. Includes MCP server.">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/speed-run/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/speed-run/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -339,6 +342,7 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -367,10 +371,12 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
     "url": "https://2389.ai"
   },
   "description": "Token-efficient code generation pipeline - parallel implementation with hosted LLM (Cerebras) for ~60% token savings. Includes MCP server.",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/speed-run/",
+  "url": "https://skills.2389.ai/plugins/speed-run/",
   "downloadUrl": "https://github.com/2389-research/speed-run",
   "softwareVersion": "1.1.1",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -390,13 +396,13 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "speed-run",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/speed-run/"
+      "item": "https://skills.2389.ai/plugins/speed-run/"
     }
   ]
 }

--- a/docs/plugins/speed-run/index.md
+++ b/docs/plugins/speed-run/index.md
@@ -1,0 +1,184 @@
+# speed-run
+
+> Token-efficient code generation pipeline - parallel implementation with hosted LLM (Cerebras) for ~60% token savings. Includes MCP server.
+
+- **Version:** 1.1.1
+- **Source:** https://github.com/2389-research/speed-run
+- **Install:** `/plugin install 2389-research/speed-run`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/speed-run
+```
+
+## README
+
+# Speed-Run
+
+Token-efficient code generation pipeline. Uses hosted LLM (Cerebras) for fast, cheap first-pass generation with Claude handling architecture and surgical fixes.
+
+| Skill | Description | Best For |
+|-------|-------------|----------|
+| `speed-run:turbo` | Direct hosted codegen | Single task, algorithmic code, boilerplate |
+| `speed-run:showdown` | Same design, parallel runners compete | Medium-high complexity, want best implementation |
+| `speed-run:any-percent` | Different approaches explored in parallel | Unsure of architecture, want to compare designs |
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install speed-run@2389-research
+```
+
+### Prerequisites
+
+Speed-run requires a Cerebras API key for hosted code generation. Free tier includes ~1M tokens/day.
+
+1. Get a key at [cloud.cerebras.ai](https://cloud.cerebras.ai)
+2. Add to `~/.claude/settings.json`:
+```json
+{
+  "env": {
+    "CEREBRAS_API_KEY": "your-key-here"
+  }
+}
+```
+3. Restart Claude Code
+
+## Flow
+
+```text
+User: "speed-run" / "turbo build" / "fast build"
+    ↓
+Check: Cerebras API key
+    ↓
+┌─────────────────────────────────────────┐
+│  Route Selection                        │
+│                                         │
+│  1. Turbo     - Direct codegen          │
+│  2. Showdown  - Parallel competition    │
+│  3. Any%      - Parallel exploration    │
+└─────────────────────────────────────────┘
+```
+
+## Quick Examples
+
+### Turbo (Direct Code Generation)
+
+```text
+User: "Use speed-run to build a rate limiter"
+
+Claude writes a contract prompt:
+  - DATA CONTRACT (exact models, types)
+  - API CONTRACT (exact routes, responses)
+  - ALGORITHM (step-by-step logic)
+  - RULES (framework, storage, error handling)
+
+Cerebras generates code → written to disk (~0.5s)
+Claude runs tests → surgical fixes if needed (1-4 lines)
+```
+
+The contract prompt pattern is like speccing a ticket for a junior dev — explicit inputs, outputs, types, and behavior. That specificity is what makes hosted LLMs reliable at 80-95% first-pass accuracy.
+
+### Showdown (Parallel Competition)
+
+```text
+User: "Use showdown for the auth system"
+
+Claude assesses complexity → spawns 3 runners
+Each runner:
+  1. Reads the shared design doc
+  2. Creates their OWN implementation plan
+  3. Generates code via Cerebras
+  4. Runs tests, fixes failures
+
+All runners dispatched in parallel.
+Fresh-eyes review → judge scores all → winner selected.
+```
+
+Key insight: each runner creates their own plan from the design doc. No shared implementation plan means genuine variation emerges naturally.
+
+### Any% (Parallel Exploration)
+
+```text
+User: "Not sure whether to use SQLite or Postgres, try both"
+
+Claude generates 2-3 architectural approaches
+Each variant:
+  1. Gets its own worktree and branch
+  2. Creates implementation plan for its approach
+  3. Generates code via Cerebras
+  4. Runs tests
+
+Same scenario tests run against all variants.
+Fresh-eyes review → judge scores all → winner selected.
+```
+
+## When to use it
+
+| Scenario | Speed-run? |
+|----------|-----------|
+| Algorithmic code, data transforms | Yes, turbo |
+| Boilerplate, scaffolding | Yes, turbo |
+| Comparing multiple implementations | Yes, showdown |
+| Exploring different architectures | Yes, any-percent |
+| Complex business logic that needs reasoning | No, use Claude directly |
+| One-liner fixes | No, overkill |
+
+## How It Compares to Test Kitchen
+
+Speed-run mirrors test-kitchen's parallel patterns but shifts code generation to a hosted LLM:
+
+| | Test Kitchen | Speed-Run |
+|---|---|---|
+| Code generation | Claude writes everything | Cerebras generates, Claude fixes |
+| Token cost | Standard | ~60-70% savings |
+| Generation speed | ~10s per file | ~0.5s per file |
+| First-pass quality | ~100% | 80-95% |
+| External dependency | None | Cerebras API key |
+
+The most direct comparison: test-kitchen's **cookoff** vs speed-run's **showdown** — same concept (multiple agents implement the same design), different execution strategy.
+
+## Available Models
+
+| Model | Speed | Notes |
+|-------|-------|-------|
+| `gpt-oss-120b` | ~3000 t/s | **Default** — best value, clean output |
+| `llama-3.3-70b` | ~2100 t/s | Reliable fallback |
+| `qwen-3-32b` | ~2600 t/s | Has verbose `<think>` tags |
+| `llama3.1-8b` | ~2200 t/s | Cheapest, may need more fixes |
+
+## Dependencies
+
+Speed-run orchestrates these skills (uses fallbacks if not installed):
+
+- `superpowers:dispatching-parallel-agents`
+- `superpowers:using-git-worktrees`
+- `superpowers:writing-plans`
+- `superpowers:executing-plans`
+- `superpowers:test-driven-development`
+- `superpowers:verification-before-completion`
+- `fresh-eyes-review:skills`
+- `scenario-testing:skills`
+- `superpowers:finishing-a-development-branch`
+
+## Documentation
+
+- [CLAUDE.md](CLAUDE.md) — Architecture, skill details, config, common mistakes
+- [Turbo Skill](./skills/turbo/SKILL.md) — Direct hosted codegen
+- [Showdown Skill](./skills/showdown/SKILL.md) — Parallel competition
+- [Any% Skill](./skills/any-percent/SKILL.md) — Parallel exploration
+- [Judge Skill](./skills/judge/SKILL.md) — Scoring framework
+
+## Origin
+
+Speed-run was born from test-kitchen's token cost problem. Running 3-5 parallel Claude agents generates a lot of expensive output tokens. By shifting first-pass code generation to Cerebras (~3000 tokens/second), we keep the same parallel exploration patterns at a fraction of the cost — Claude focuses on what it's best at: architecture, orchestration, and surgical fixes.
+
+---
+
+If Speed Run saved you tokens and time, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/summarize-meetings/index.html
+++ b/docs/plugins/summarize-meetings/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/summarize-meetings/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/summarize-meetings/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/summarize-meetings/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/summarize-meetings/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/summarize-meetings/">
   <meta property="og:title" content="summarize-meetings — Personal & Strategy Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Batch-process meeting transcripts from Obsidian vault into structured summaries with knowledge graph updates, people notes, and concept extraction">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/summarize-meetings/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/summarize-meetings/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/summarize-meetings/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/summarize-meetings/">
   <meta property="twitter:title" content="summarize-meetings — Personal & Strategy Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Batch-process meeting transcripts from Obsidian vault into structured summaries with knowledge graph updates, people notes, and concept extraction">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/summarize-meetings/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/summarize-meetings/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -271,6 +274,7 @@
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -299,10 +303,12 @@
     "url": "https://2389.ai"
   },
   "description": "Batch-process meeting transcripts from Obsidian vault into structured summaries with knowledge graph updates, people notes, and concept extraction",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/summarize-meetings/",
+  "url": "https://skills.2389.ai/plugins/summarize-meetings/",
   "downloadUrl": "https://github.com/2389-research/summarize-meetings",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -322,13 +328,13 @@
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "summarize-meetings",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/summarize-meetings/"
+      "item": "https://skills.2389.ai/plugins/summarize-meetings/"
     }
   ]
 }

--- a/docs/plugins/summarize-meetings/index.md
+++ b/docs/plugins/summarize-meetings/index.md
@@ -1,0 +1,67 @@
+# summarize-meetings
+
+> Batch-process meeting transcripts from Obsidian vault into structured summaries with knowledge graph updates, people notes, and concept extraction
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/summarize-meetings
+- **Install:** `/plugin install 2389-research/summarize-meetings`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/summarize-meetings
+```
+
+## README
+
+# Summarize Meetings
+
+Meeting transcripts pile up. The names, the action items, the project ideas, they're all in there but nobody's going back to read them. This skill turns a backlog of Granola transcripts into a connected Obsidian knowledge graph. Processes meetings in monthly batches, extracts the stuff that matters, and wires it all together with wiki-links. We used it to process ~600 meetings into something actually useful: [My Now Immaculate Knowledge Graph of Life](https://harper.blog/2026/03/11/2026-immaculate-knowledge-graph/)
+
+![network-annotated_hu_dc5f11550bad1d72](https://github.com/user-attachments/assets/76a71ed6-018a-4dc6-8aff-79c2d76b86df)
+*Obsidian graph view after processing ~600 meetings. Nodes are people and concepts, edges are co-occurrence in the same meeting.*
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install summarize-meetings@2389-research
+```
+
+## What it does
+
+Point this at a month of meeting transcripts and it will:
+
+- Read each transcript, skip the junk (empty stubs, scheduling fragments, recording setup chats)
+- Dispatch 10-15 parallel agents to process the real meetings
+- Write a summary file for each meeting with YAML frontmatter and a narrative recap
+- Create or update People notes in `People/` (checks for existing entries and aliases first)
+- Pull out concepts worth their own atomic note in `Concepts/`
+- Stub out any projects mentioned that don't already exist
+- Report back with a table of what got processed and what got skipped
+
+## What gets extracted
+
+From each meeting, agents pull out seven categories: people, action items, project ideas, blog ideas, knowledge graph connections, concepts, and general ideas. The summary file includes all of these plus a 2-4 paragraph narrative that reads like a real meeting recap — what happened, what mattered, what the vibe was.
+
+## Triage
+
+Not everything in `Meetings/transcripts/` is worth a summary. The skill skips files that are empty stubs, have fewer than 20 words of real content, are garbled recordings, or are medical appointments and kid-related content. Sparse but real notes (like bullet points from a fundraising call) still get processed.
+
+## How it works
+
+```
+Scan month → Triage → Dispatch agents in waves → Compile report → Post update
+```
+
+Agents run in parallel (waves of 10-15) and each one handles a single transcript end-to-end. Large files (50K+) get chunked automatically.
+
+## Documentation
+
+The full workflow, templates, and extraction rules are in [skills/SKILL.md](skills/SKILL.md).
+
+## Like this?
+
+If Summarize Meetings saved you from transcript purgatory, a star ⭐️ helps us know it's landing.
+

--- a/docs/plugins/terminal-title/index.html
+++ b/docs/plugins/terminal-title/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/terminal-title/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/terminal-title/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/terminal-title/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/terminal-title/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/terminal-title/">
   <meta property="og:title" content="terminal-title — Infrastructure Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Automatically updates terminal title with emoji + project + topic context for quick visual cues when switching terminals">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/terminal-title/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/terminal-title/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/terminal-title/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/terminal-title/">
   <meta property="twitter:title" content="terminal-title — Infrastructure Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Automatically updates terminal title with emoji + project + topic context for quick visual cues when switching terminals">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/terminal-title/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/terminal-title/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -274,6 +277,7 @@ export TERMINAL_TITLE_EMOJI=💼
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -302,10 +306,12 @@ export TERMINAL_TITLE_EMOJI=💼
     "url": "https://2389.ai"
   },
   "description": "Automatically updates terminal title with emoji + project + topic context for quick visual cues when switching terminals",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/terminal-title/",
+  "url": "https://skills.2389.ai/plugins/terminal-title/",
   "downloadUrl": "https://github.com/2389-research/terminal-title",
   "softwareVersion": "1.1.2",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -325,13 +331,13 @@ export TERMINAL_TITLE_EMOJI=💼
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "terminal-title",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/terminal-title/"
+      "item": "https://skills.2389.ai/plugins/terminal-title/"
     }
   ]
 }

--- a/docs/plugins/terminal-title/index.md
+++ b/docs/plugins/terminal-title/index.md
@@ -1,0 +1,86 @@
+# terminal-title
+
+> Automatically updates terminal title with emoji + project + topic context for quick visual cues when switching terminals
+
+- **Version:** 1.1.2
+- **Source:** https://github.com/2389-research/terminal-title
+- **Install:** `/plugin install 2389-research/terminal-title`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/terminal-title
+```
+
+## README
+
+# Terminal title
+
+Automatically updates your terminal title with emoji + project + topic context. Works on Windows, macOS, and Linux.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install terminal-title@2389-research
+```
+
+### Environment variables
+
+Add these to your `.bashrc`, `.zshrc`, or shell profile:
+
+```bash
+# Set to 1 to disable automatic terminal title updates
+export CLAUDE_CODE_DISABLE_TERMINAL_TITLE=0
+
+# Optional: set an emoji prefix for your terminal title.
+# Useful for distinguishing work vs personal terminals at a glance.
+export TERMINAL_TITLE_EMOJI=💼
+```
+
+If `TERMINAL_TITLE_EMOJI` is not set, the plugin defaults to 🎉.
+
+### Platform-specific setup
+
+Windows users need PowerShell 7+ (`pwsh`) installed and on PATH. The plugin picks it up automatically.
+
+Unix/Linux/macOS users don't need to do anything extra.
+
+## What this plugin does
+
+One skill: `terminal-title` -- manages your terminal title based on project and topic context.
+
+The title updates automatically at session start, and again whenever the topic changes. The emoji prefix gives you a quick visual cue when switching between terminal windows.
+
+## How it works
+
+A session start hook fires the terminal-title skill, which:
+
+1. Detects your OS (Windows, macOS, Linux)
+2. Figures out the current project from the working directory, git repo, or package.json
+3. Infers the topic from conversation context
+4. Reads `TERMINAL_TITLE_EMOJI` from the environment (or defaults to 🎉)
+5. Updates the terminal title via a platform-specific script (`.ps1` on Windows, `.sh` everywhere else)
+
+The title format is: `$EMOJI ProjectName - Topic`
+
+## Examples
+
+```text
+💼 OneOnOne - Firebase Config
+💼 Claude Plugins - Terminal Title
+🎉 dotfiles - zsh config
+```
+
+## Documentation
+
+- [Design document](docs/2025-11-14-terminal-title-skill-design.md)
+- [Implementation plan](docs/2025-11-14-terminal-title-implementation.md)
+
+---
+
+If Terminal Title helps you keep track of 12 open sessions, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/test-kitchen/index.html
+++ b/docs/plugins/test-kitchen/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/test-kitchen/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/test-kitchen/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/test-kitchen/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/test-kitchen/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/test-kitchen/">
   <meta property="og:title" content="test-kitchen — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Parallel exploration of implementation approaches - implements multiple variants simultaneously and lets tests determine the winner">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/test-kitchen/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/test-kitchen/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/test-kitchen/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/test-kitchen/">
   <meta property="twitter:title" content="test-kitchen — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Parallel exploration of implementation approaches - implements multiple variants simultaneously and lets tests determine the winner">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/test-kitchen/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/test-kitchen/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -349,6 +352,7 @@ Which approach?
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -377,10 +381,12 @@ Which approach?
     "url": "https://2389.ai"
   },
   "description": "Parallel exploration of implementation approaches - implements multiple variants simultaneously and lets tests determine the winner",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/test-kitchen/",
+  "url": "https://skills.2389.ai/plugins/test-kitchen/",
   "downloadUrl": "https://github.com/2389-research/test-kitchen",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -400,13 +406,13 @@ Which approach?
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "test-kitchen",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/test-kitchen/"
+      "item": "https://skills.2389.ai/plugins/test-kitchen/"
     }
   ]
 }

--- a/docs/plugins/test-kitchen/index.md
+++ b/docs/plugins/test-kitchen/index.md
@@ -1,0 +1,178 @@
+# test-kitchen
+
+> Parallel exploration of implementation approaches - implements multiple variants simultaneously and lets tests determine the winner
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/test-kitchen
+- **Install:** `/plugin install 2389-research/test-kitchen`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/test-kitchen
+```
+
+## README
+
+# Test Kitchen
+
+You have a spec. Three valid approaches exist. Instead of guessing which one to build, Test Kitchen builds all of them in parallel git worktrees and lets your tests pick the winner.
+
+Read more: [Cookoff: Same Spec, Different Code](https://2389.ai/posts/cookoff-same-spec-different-code/) · [Omakase: Show Me](https://2389.ai/posts/omakase-show-me/)
+
+Parallel implementation framework with two gate skills:
+
+| Skill | Gate | Trigger |
+|-------|------|---------|
+| `test-kitchen:omakase-off` | **Entry** | FIRST on any build/create/implement request |
+| `test-kitchen:cookoff` | **Exit** | At design→implementation transition |
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install test-kitchen@2389-research
+```
+
+## Flow
+
+```
+"Build X" / "Create Y" / "Implement Z"
+    ↓
+┌─────────────────────────────────────┐
+│  OMAKASE-OFF (entry gate)           │
+│  Wraps brainstorming                │
+│                                     │
+│  Choice:                            │
+│  1. Brainstorm together             │
+│  2. Omakase (3-5 parallel designs)  │
+└─────────────────────────────────────┘
+    ↓
+[Brainstorming / Design phase]
+    ↓
+Design complete, "let's implement"
+    ↓
+┌─────────────────────────────────────┐
+│  COOKOFF (exit gate)                │
+│  Wraps implementation               │
+│                                     │
+│  Choice:                            │
+│  1. Cookoff (2-5 parallel agents)   │
+│  2. Single subagent                 │
+│  3. Local implementation            │
+└─────────────────────────────────────┘
+    ↓
+[Implementation]
+```
+
+## Quick examples
+
+### Entry gate: omakase-off
+
+When you make a build/create request:
+```
+User: "Build a notification system"
+
+Claude: I'm using test-kitchen:omakase-off.
+
+How would you like to explore this?
+
+1. Brainstorm together - We'll work through the design step by step
+2. Omakase - I'll generate 3-5 best approaches, implement in parallel, tests pick winner
+
+Which approach?
+```
+
+Option 1 (Brainstorm) proceeds to brainstorming skill (or fallback brainstorming), with passive slot detection.
+
+Option 2 (Omakase) does the following:
+- Quick context gathering (1-2 questions)
+- Generate 3-5 architectural approaches
+- Implement ALL in parallel via git worktrees
+- Run same scenario tests on each
+- Fresh-eyes review survivors
+- Present comparison, user picks winner
+
+During brainstorming, slot detection can also trigger it:
+```
+Claude: What storage approach would you prefer?
+User: "not sure, either could work"
+
+Claude: [marks storage as architectural slot]
+
+Claude: For authentication?
+User: "no preference, you pick"
+
+Claude: [marks auth as slot, detects 2+ uncertain responses]
+
+You seem flexible on the approach. Would you like to:
+1. I'll pick what seems best and continue
+2. Explore multiple approaches in parallel (omakase-off)
+   → I'll implement 2-3 variants and let tests decide
+```
+
+### Exit gate: cookoff
+
+```
+User: "Looks good, let's implement"
+
+Claude: I'm using test-kitchen:cookoff.
+
+How would you like to implement this design?
+
+1. Cookoff (recommended) - 3 parallel agents, each creates own plan, pick best
+   → Complexity: medium feature
+2. Single subagent - One agent plans and implements
+3. Local - Plan and implement here
+
+Which approach?
+```
+
+Option 1 (Cookoff):
+- Each agent reads the same design doc
+- Each agent creates their OWN implementation plan
+- All implement in parallel
+- Fresh-eyes review, compare results
+- User picks winner
+
+Options 2/3 -- single agent or local implementation proceeds normally.
+
+## Why aggressive triggers
+
+Skills can't passively detect "uncertainty" or "readiness" -- they must claim specific moments in the conversation flow.
+
+- Omakase-off claims the BUILD/CREATE moment (before brainstorming)
+- Cookoff claims the IMPLEMENT moment (after design)
+
+## Dependencies
+
+Test Kitchen orchestrates these skills (falls back gracefully if not installed):
+
+- `superpowers:brainstorming`
+- `superpowers:writing-plans`
+- `superpowers:executing-plans`
+- `superpowers:using-git-worktrees`
+- `superpowers:dispatching-parallel-agents`
+- `superpowers:test-driven-development`
+- `superpowers:verification-before-completion`
+- `scenario-testing:skills`
+- `fresh-eyes-review:skills`
+- `superpowers:finishing-a-development-branch`
+
+## Documentation
+
+- [CLAUDE.md](./CLAUDE.md) -- full plugin instructions
+- [Omakase-off skill](./skills/omakase-off/SKILL.md) -- entry gate (wraps brainstorming)
+- [Cookoff skill](./skills/cookoff/SKILL.md) -- exit gate (wraps implementation)
+
+## Origin
+
+Named after a restaurant test kitchen, where chefs try multiple approaches before putting a dish on the menu.
+
+---
+
+If Test Kitchen saved you from building the wrong approach first, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/worldview-synthesis/index.html
+++ b/docs/plugins/worldview-synthesis/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/worldview-synthesis/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/worldview-synthesis/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/worldview-synthesis/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/worldview-synthesis/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/worldview-synthesis/">
   <meta property="og:title" content="worldview-synthesis — Personal & Strategy Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Systematic worldview articulation - surface beliefs, identify tensions, generate narrative outputs for personal philosophy documentation">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/worldview-synthesis/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/worldview-synthesis/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/worldview-synthesis/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/worldview-synthesis/">
   <meta property="twitter:title" content="worldview-synthesis — Personal & Strategy Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Systematic worldview articulation - surface beliefs, identify tensions, generate narrative outputs for personal philosophy documentation">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/worldview-synthesis/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/worldview-synthesis/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -293,6 +296,7 @@ Find the cracks. Leave no trace.
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -321,10 +325,12 @@ Find the cracks. Leave no trace.
     "url": "https://2389.ai"
   },
   "description": "Systematic worldview articulation - surface beliefs, identify tensions, generate narrative outputs for personal philosophy documentation",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/worldview-synthesis/",
+  "url": "https://skills.2389.ai/plugins/worldview-synthesis/",
   "downloadUrl": "https://github.com/2389-research/worldview-synthesis",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -344,13 +350,13 @@ Find the cracks. Leave no trace.
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "worldview-synthesis",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/worldview-synthesis/"
+      "item": "https://skills.2389.ai/plugins/worldview-synthesis/"
     }
   ]
 }

--- a/docs/plugins/worldview-synthesis/index.md
+++ b/docs/plugins/worldview-synthesis/index.md
@@ -1,0 +1,94 @@
+# worldview-synthesis
+
+> Systematic worldview articulation - surface beliefs, identify tensions, generate narrative outputs for personal philosophy documentation
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/worldview-synthesis
+- **Install:** `/plugin install 2389-research/worldview-synthesis`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/worldview-synthesis
+```
+
+## README
+
+# Worldview Synthesis Plugin
+
+Surface your beliefs, identify the tensions between them, and generate narrative outputs for personal philosophy documentation.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install worldview-synthesis@2389-research
+```
+
+## What this plugin provides
+
+### Skills
+
+- `worldview-synthesis` -- methodology for articulating personal philosophy through structured interrogation, tension mapping, and narrative generation
+
+### Reference materials
+
+- `interrogation-questions.md` -- 6 rounds of ready-to-use questions covering mortality, body, relationships, emotion, work, ethics, society, and future
+
+## Quick example
+
+Start with: "Help me articulate my worldview"
+
+The skill guides you through:
+1. Bootstrap -- create project structure for beliefs and narratives
+2. Seed -- extract ideas from your influences (books, people, experiences)
+3. Interrogate -- 4-6 rounds of multi-choice questions across 20 domains
+4. Capture tensions -- name contradictions, don't resolve them
+5. Generate narratives -- mission, thesis, synopsis, full narrative
+6. Iterate -- a worldview is living, update as you evolve
+
+## Core principle
+
+A worldview isn't a list of opinions. It's a graph of beliefs with tensions. The goal is to surface what you already believe, name the contradictions, and synthesize into something you can share.
+
+## Output examples
+
+Mission (~100 words):
+```
+Put people first. Prepare for what's coming. Fight anyway.
+Find the cracks. Leave no trace.
+```
+
+Idea node:
+```yaml
+- id: strategic-ruthlessness
+  claim: "Sometimes you have to crush opponents"
+  confidence: 0.7
+  tensions: [collaboration-over-competition]
+```
+
+Tension:
+```yaml
+- id: collaboration-vs-ruthlessness
+  status: embraced  # Live in the paradox
+```
+
+## When this skill applies
+
+- "I want to articulate my values"
+- "Help me figure out what I believe"
+- Writing a manifesto or leadership philosophy
+- Defining company culture
+- Personal philosophy documentation
+
+## Links
+
+- [Plugin CLAUDE.md](./CLAUDE.md) -- development instructions
+
+---
+
+If this helped you articulate what you actually believe, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/plugins/xtool/index.html
+++ b/docs/plugins/xtool/index.html
@@ -13,22 +13,25 @@
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/plugins/xtool/">
+  <link rel="canonical" href="https://skills.2389.ai/plugins/xtool/">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="https://skills.2389.ai/plugins/xtool/index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/plugins/xtool/">
+  <meta property="og:url" content="https://skills.2389.ai/plugins/xtool/">
   <meta property="og:title" content="xtool — Development Plugin for Claude Code | 2389 Research">
   <meta property="og:description" content="Xcode-free iOS development with xtool - build SwiftPM apps on Linux, Windows, and macOS without Xcode">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/plugins/xtool/og-image.png">
+  <meta property="og:image" content="https://skills.2389.ai/plugins/xtool/og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/plugins/xtool/">
+  <meta property="twitter:url" content="https://skills.2389.ai/plugins/xtool/">
   <meta property="twitter:title" content="xtool — Development Plugin for Claude Code | 2389 Research">
   <meta property="twitter:description" content="Xcode-free iOS development with xtool - build SwiftPM apps on Linux, Windows, and macOS without Xcode">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/plugins/xtool/og-image.png">
+  <meta property="twitter:image" content="https://skills.2389.ai/plugins/xtool/og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -280,6 +283,7 @@ xtool dev
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="../../glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -308,10 +312,12 @@ xtool dev
     "url": "https://2389.ai"
   },
   "description": "Xcode-free iOS development with xtool - build SwiftPM apps on Linux, Windows, and macOS without Xcode",
-  "url": "https://2389-research.github.io/claude-plugins/plugins/xtool/",
+  "url": "https://skills.2389.ai/plugins/xtool/",
   "downloadUrl": "https://github.com/2389-research/xtool",
   "softwareVersion": "1.0.0",
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://opensource.org/licenses/MIT",
+  "datePublished": "2026-04-20",
+  "dateModified": "2026-05-19"
 }
   </script>
 
@@ -331,13 +337,13 @@ xtool dev
       "@type": "ListItem",
       "position": 2,
       "name": "Plugin Marketplace",
-      "item": "https://2389-research.github.io/claude-plugins/"
+      "item": "https://skills.2389.ai/"
     },
     {
       "@type": "ListItem",
       "position": 3,
       "name": "xtool",
-      "item": "https://2389-research.github.io/claude-plugins/plugins/xtool/"
+      "item": "https://skills.2389.ai/plugins/xtool/"
     }
   ]
 }

--- a/docs/plugins/xtool/index.md
+++ b/docs/plugins/xtool/index.md
@@ -1,0 +1,77 @@
+# xtool
+
+> Xcode-free iOS development with xtool - build SwiftPM apps on Linux, Windows, and macOS without Xcode
+
+- **Version:** 1.0.0
+- **Source:** https://github.com/2389-research/xtool
+- **Install:** `/plugin install 2389-research/xtool`
+
+## Install via marketplace
+
+```
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install 2389-research/xtool
+```
+
+## README
+
+# xtool Plugin
+
+Xcode-free iOS development with xtool - build SwiftPM apps on Linux, Windows, and macOS without Xcode.
+
+## Installation
+
+```bash
+/plugin marketplace add 2389-research/claude-plugins
+/plugin install xtool@2389-research
+```
+
+## What this plugin provides
+
+### Skills
+
+- `using-xtool` -- guide for xtool iOS development including project creation, app extensions (widgets, share extensions), and configuration
+
+## Quick example
+
+Create a new iOS app:
+```bash
+xtool new MyApp
+cd MyApp
+xtool dev
+```
+
+Add a widget extension:
+1. Add product + target to `Package.swift`
+2. Configure in `xtool.yml` under `extensions:`
+3. Create `Sources/MyWidget/Widget.swift`
+4. Create `MyWidget-Info.plist` with `NSExtensionPointIdentifier`
+5. Run `xtool dev`
+
+## When this skill applies
+
+The skill auto-triggers on:
+- Mentions of `xtool`
+- SwiftPM iOS app development
+- Building iOS apps on Linux/Windows
+- App extension setup (widgets, share extensions)
+
+## How xtool differs from XcodeGen/Tuist
+
+| xtool Uses | NOT These |
+|------------|-----------|
+| `xtool.yml` | `project.yml`, `Project.swift` |
+| `Package.swift` (SwiftPM) | Xcode project files |
+| `xtool dev` | `xtool build`, `xtool run` |
+
+## Links
+
+- [xtool GitHub](https://github.com/nickyramone/xtool)
+- [Plugin CLAUDE.md](./CLAUDE.md) -- development instructions
+
+---
+
+If xtool freed you from Xcode, a ⭐ helps us know it's landing.
+
+Built by [2389](https://2389.ai) · Part of the [Claude Code plugin marketplace](https://github.com/2389-research/claude-plugins)
+

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -2,5 +2,5 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://2389-research.github.io/claude-plugins/sitemap.xml
+Sitemap: https://skills.2389.ai/sitemap.xml
 Crawl-delay: 1

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -1,0 +1,37 @@
+# Sitemap
+
+Pages on this site, for AI agents and other tools that prefer markdown over XML.
+
+- [Plugin Marketplace](https://skills.2389.ai/) — homepage with the full plugin catalog
+- [Glossary](https://skills.2389.ai/glossary/) — terms used across the marketplace
+- [AGENTS.md](https://skills.2389.ai/AGENTS.md) — site overview for AI agents
+- [llms.txt](https://skills.2389.ai/llms.txt) — structured site index per llmstxt.org
+
+## Plugins
+
+- [css-development](https://skills.2389.ai/plugins/css-development/) — CSS development workflows with Tailwind composition, semantic naming, and dark mode by default
+- [firebase-development](https://skills.2389.ai/plugins/firebase-development/) — Firebase project workflows including setup, features, debugging, and validation
+- [landing-page-design](https://skills.2389.ai/plugins/landing-page-design/) — Create high-converting, visually distinctive landing pages with Vibe Discovery process and anti-AI-slop principles
+- [xtool](https://skills.2389.ai/plugins/xtool/) — Xcode-free iOS development with xtool - build SwiftPM apps on Linux, Windows, and macOS without Xcode
+- [building-multiagent-systems](https://skills.2389.ai/plugins/building-multiagent-systems/) — Architecture patterns for multi-agent systems with orchestrators, sub-agents, and tool coordination
+- [speed-run](https://skills.2389.ai/plugins/speed-run/) — Token-efficient code generation pipeline - parallel implementation with hosted LLM (Cerebras) for ~60% token savings. Includes MCP server.
+- [test-kitchen](https://skills.2389.ai/plugins/test-kitchen/) — Parallel exploration of implementation approaches - implements multiple variants simultaneously and lets tests determine the winner
+- [simmer](https://skills.2389.ai/plugins/simmer/) — Iterative artifact refinement with investigation-first judge board - constructs problem-specific judges that read the code, understand the problem, and propose evidence-based improvements
+- [scenario-testing](https://skills.2389.ai/plugins/scenario-testing/) — End-to-end testing with real dependencies - no mocks allowed; scenarios with real data are the only source of truth
+- [fresh-eyes-review](https://skills.2389.ai/plugins/fresh-eyes-review/) — Mandatory final sanity check before commits/PRs - catches security vulnerabilities, logic errors, and bugs that slip through tests
+- [documentation-audit](https://skills.2389.ai/plugins/documentation-audit/) — Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection
+- [ceo-personal-os](https://skills.2389.ai/plugins/ceo-personal-os/) — Personal operating system for executives - reflection frameworks, goal systems, coaching-style reviews (Gustin, Ferriss, Robbins, Lieberman, Campbell, Eisenmann, Collins, Martell, Gerber, Blank)
+- [worldview-synthesis](https://skills.2389.ai/plugins/worldview-synthesis/) — Systematic worldview articulation - surface beliefs, identify tensions, generate narrative outputs for personal philosophy documentation
+- [deliberation](https://skills.2389.ai/plugins/deliberation/) — Decision-making through deliberation - seeking unity through discernment rather than consensus through debate
+- [terminal-title](https://skills.2389.ai/plugins/terminal-title/) — Automatically updates terminal title with emoji + project + topic context for quick visual cues when switching terminals
+- [slack-mcp](https://skills.2389.ai/plugins/slack-mcp/) — Slack workspace integration MCP server - create channels, invite users, post messages, manage threads for team collaboration
+- [remote-system-maintenance](https://skills.2389.ai/plugins/remote-system-maintenance/) — Structured procedures for Linux system diagnostics and maintenance via SSH/tmux with Ubuntu/Debian cleanup checklists
+- [binary-re](https://skills.2389.ai/plugins/binary-re/) — Agentic binary reverse engineering for ELF binaries on ARM64, ARMv7, x86_64 - hypothesis-driven analysis with radare2, Ghidra, GDB, QEMU
+- [review-squad](https://skills.2389.ai/plugins/review-squad/) — Dispatch panels of specialized subagents to review projects — expert audits, first-impression personas, task-completion flows, and pedantic nitpicks
+- [git-repo-prep](https://skills.2389.ai/plugins/git-repo-prep/) — Prepare codebases for public/open-source release and audit them for openness - full lifecycle prep or standalone review
+- [prbuddy](https://skills.2389.ai/plugins/prbuddy/) — PR health assistant - monitors CI, triages review comments, fixes issues with systematic prevention. Uses gh CLI and gh-pr-review extension.
+- [summarize-meetings](https://skills.2389.ai/plugins/summarize-meetings/) — Batch-process meeting transcripts from Obsidian vault into structured summaries with knowledge graph updates, people notes, and concept extraction
+- [jam](https://skills.2389.ai/plugins/jam/) — Parallel exploration powered by diverse perspectives - independent agent panels propose, build variants in worktrees, review, pick a winner, and synthesize the best of all variants into the final result
+- [agent-drugs](https://skills.2389.ai/plugins/agent-drugs/) — Digital drugs that modify AI behavior through prompt injection
+- [socialmedia](https://skills.2389.ai/plugins/socialmedia/) — A server that provides social media functionality for AI agents, enabling them to interact in team-based discussions.
+- [journal](https://skills.2389.ai/plugins/journal/) — A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,163 +1,169 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/</loc>
+    <loc>https://skills.2389.ai/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/css-development/</loc>
+    <loc>https://skills.2389.ai/glossary/</loc>
+    <lastmod>2026-05-19</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://skills.2389.ai/plugins/css-development/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/firebase-development/</loc>
+    <loc>https://skills.2389.ai/plugins/firebase-development/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/landing-page-design/</loc>
+    <loc>https://skills.2389.ai/plugins/landing-page-design/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/xtool/</loc>
+    <loc>https://skills.2389.ai/plugins/xtool/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/building-multiagent-systems/</loc>
+    <loc>https://skills.2389.ai/plugins/building-multiagent-systems/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/speed-run/</loc>
+    <loc>https://skills.2389.ai/plugins/speed-run/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/test-kitchen/</loc>
+    <loc>https://skills.2389.ai/plugins/test-kitchen/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/simmer/</loc>
+    <loc>https://skills.2389.ai/plugins/simmer/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/scenario-testing/</loc>
+    <loc>https://skills.2389.ai/plugins/scenario-testing/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/fresh-eyes-review/</loc>
+    <loc>https://skills.2389.ai/plugins/fresh-eyes-review/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/documentation-audit/</loc>
+    <loc>https://skills.2389.ai/plugins/documentation-audit/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/ceo-personal-os/</loc>
+    <loc>https://skills.2389.ai/plugins/ceo-personal-os/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/worldview-synthesis/</loc>
+    <loc>https://skills.2389.ai/plugins/worldview-synthesis/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/deliberation/</loc>
+    <loc>https://skills.2389.ai/plugins/deliberation/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/terminal-title/</loc>
+    <loc>https://skills.2389.ai/plugins/terminal-title/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/slack-mcp/</loc>
+    <loc>https://skills.2389.ai/plugins/slack-mcp/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/remote-system-maintenance/</loc>
+    <loc>https://skills.2389.ai/plugins/remote-system-maintenance/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/binary-re/</loc>
+    <loc>https://skills.2389.ai/plugins/binary-re/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/review-squad/</loc>
+    <loc>https://skills.2389.ai/plugins/review-squad/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/git-repo-prep/</loc>
+    <loc>https://skills.2389.ai/plugins/git-repo-prep/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/prbuddy/</loc>
+    <loc>https://skills.2389.ai/plugins/prbuddy/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/summarize-meetings/</loc>
+    <loc>https://skills.2389.ai/plugins/summarize-meetings/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/jam/</loc>
+    <loc>https://skills.2389.ai/plugins/jam/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/agent-drugs/</loc>
+    <loc>https://skills.2389.ai/plugins/agent-drugs/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/socialmedia/</loc>
+    <loc>https://skills.2389.ai/plugins/socialmedia/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2389-research.github.io/claude-plugins/plugins/journal/</loc>
+    <loc>https://skills.2389.ai/plugins/journal/</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/scripts/generate-site.js
+++ b/scripts/generate-site.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 // Read marketplace.json
 const marketplace = JSON.parse(
@@ -11,6 +11,19 @@ const marketplace = JSON.parse(
 );
 
 const INTERNAL_MARKETPLACE_COMMAND = '/plugin marketplace add 2389-research/claude-plugins';
+const SITE_URL = 'https://skills.2389.ai';
+const BUILD_DATE = new Date().toISOString().slice(0, 10);
+
+// Use git commit dates so generated metadata only changes when content actually changes
+function getLastModDate(targetPath) {
+  try {
+    return execFileSync('git', ['log', '-1', '--format=%cs', '--', targetPath], { encoding: 'utf8' }).trim() || BUILD_DATE;
+  } catch {
+    return BUILD_DATE;
+  }
+}
+
+const MARKETPLACE_LASTMOD = getLastModDate('.claude-plugin/marketplace.json');
 
 // Group plugins by category
 const categories = {
@@ -91,8 +104,11 @@ function convertRepoLinks(html, pluginName, repoName) {
   const repo = repoName || `2389-research/${pluginName}`;
 
   // Match <a href="..."> where href is a relative path to .md file or directory
+  // Covers: known dirs (skills/, docs/, tests/, hooks/), any root-level .md file
+  // (CLAUDE.md, README.md, ROADMAP.md, ARCHITECTURE.md, CONTRIBUTING.md, etc.),
+  // and parent-relative paths.
   return html.replace(
-    /<a href="(\.?\.?\/?)((?:skills|docs|tests|hooks)(?:\/[^"]+)?|CLAUDE\.md|README\.md|\.\.\/?[^"]*)"([^>]*)>([^<]*)<\/a>/g,
+    /<a href="(\.?\.?\/?)((?:skills|docs|tests|hooks)(?:\/[^"]+)?|[^"\/]+\.md|\.\.\/?[^"]*)"([^>]*)>([^<]*)<\/a>/g,
     (match, prefix, linkPath, attrs, linkText) => {
       // Normalize the path
       let normalizedPath = linkPath.replace(/^\.\//, '');
@@ -384,22 +400,25 @@ function generateHead(title, description, canonicalPath, extraKeywords) {
   <meta name="robots" content="index, follow">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="https://2389-research.github.io/claude-plugins/${canonicalPath}">
+  <link rel="canonical" href="${SITE_URL}/${canonicalPath}">
+
+  <!-- Markdown mirror for AI agents -->
+  <link rel="alternate" type="text/markdown" href="${SITE_URL}/${canonicalPath}index.md">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://2389-research.github.io/claude-plugins/${canonicalPath}">
+  <meta property="og:url" content="${SITE_URL}/${canonicalPath}">
   <meta property="og:title" content="${title} | 2389 Research">
   <meta property="og:description" content="${description}">
-  <meta property="og:image" content="https://2389-research.github.io/claude-plugins/${canonicalPath}og-image.png">
+  <meta property="og:image" content="${SITE_URL}/${canonicalPath}og-image.png">
   <meta property="og:site_name" content="2389 Research Plugin Marketplace">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://2389-research.github.io/claude-plugins/${canonicalPath}">
+  <meta property="twitter:url" content="${SITE_URL}/${canonicalPath}">
   <meta property="twitter:title" content="${title} | 2389 Research">
   <meta property="twitter:description" content="${description}">
-  <meta property="twitter:image" content="https://2389-research.github.io/claude-plugins/${canonicalPath}og-image.png">
+  <meta property="twitter:image" content="${SITE_URL}/${canonicalPath}og-image.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔌</text></svg>">
@@ -468,6 +487,7 @@ function generateFooter(isPluginPage = false) {
           <a href="https://docs.claude.com/en/docs/claude-code" data-tinylytics-event="footer.resource" data-tinylytics-event-value="claude-code-docs">Claude Code Docs</a>
           <a href="https://docs.claude.com/en/docs/claude-code/skills" data-tinylytics-event="footer.resource" data-tinylytics-event-value="skills-guide">Skills Guide</a>
           <a href="https://docs.claude.com/en/docs/claude-code/plugins" data-tinylytics-event="footer.resource" data-tinylytics-event-value="plugin-dev">Plugin Development</a>
+          <a href="${homeLink}glossary/" data-tinylytics-event="footer.resource" data-tinylytics-event-value="glossary">Glossary</a>
         </div>
       </div>
     </div>
@@ -633,10 +653,12 @@ function generatePluginPage(plugin) {
       "url": "https://2389.ai"
     },
     "description": description,
-    "url": `https://2389-research.github.io/claude-plugins/plugins/${plugin.name}/`,
+    "url": `${SITE_URL}/plugins/${plugin.name}/`,
     "downloadUrl": sourceUrl,
     "softwareVersion": plugin.version || "1.0.0",
-    "license": "https://opensource.org/licenses/MIT"
+    "license": "https://opensource.org/licenses/MIT",
+    "datePublished": MARKETPLACE_LASTMOD,
+    "dateModified": BUILD_DATE
   };
 
   // Build a descriptive title from the plugin name and category
@@ -769,13 +791,13 @@ ${generateQuickInstallSteps(plugin)}
         "@type": "ListItem",
         "position": 2,
         "name": "Plugin Marketplace",
-        "item": "https://2389-research.github.io/claude-plugins/"
+        "item": `${SITE_URL}/`
       },
       {
         "@type": "ListItem",
         "position": 3,
         "name": plugin.name,
-        "item": `https://2389-research.github.io/claude-plugins/plugins/${plugin.name}/`
+        "item": `${SITE_URL}/plugins/${plugin.name}/`
       }
     ]
   }, null, 2)}
@@ -999,10 +1021,12 @@ ${generateCategorySections()}
       "url": "https://2389.ai"
     },
     "description": "Open source Claude Code plugins and MCP servers for development workflows, testing, and AI agent capabilities",
-    "url": "https://2389-research.github.io/claude-plugins/",
+    "url": "${SITE_URL}/",
     "downloadUrl": "https://github.com/2389-research/claude-plugins",
     "softwareVersion": "1.0.0",
-    "license": "https://opensource.org/licenses/MIT"
+    "license": "https://opensource.org/licenses/MIT",
+    "datePublished": "${MARKETPLACE_LASTMOD}",
+    "dateModified": "${BUILD_DATE}"
   }
   </script>
 
@@ -1022,7 +1046,7 @@ ${generateCategorySections()}
         "@type": "ListItem",
         "position": 2,
         "name": "Plugin Marketplace",
-        "item": "https://2389-research.github.io/claude-plugins/"
+        "item": "${SITE_URL}/"
       }
     ]
   }
@@ -1040,7 +1064,7 @@ ${generateCategorySections()}
       "@type": "ListItem",
       "position": i + 1,
       "name": p.name,
-      "url": `https://2389-research.github.io/claude-plugins/plugins/${p.name}/`
+      "url": `${SITE_URL}/plugins/${p.name}/`
     }))
   }, null, 2)}
   </script>
@@ -1075,29 +1099,17 @@ marketplace.plugins.forEach(plugin => {
   fs.writeFileSync(`${pluginDir}/index.html`, generatePluginPage(plugin));
 });
 
-// Generate sitemap with all pages
-// Use git commit dates so the sitemap only changes when content actually changes
-const { execFileSync } = require('child_process');
-function getLastModDate(targetPath) {
-  try {
-    return execFileSync('git', ['log', '-1', '--format=%cs', '--', targetPath], { encoding: 'utf8' }).trim();
-  } catch {
-    return '2026-01-13'; // fallback: repo creation date
-  }
-}
-
-const marketplaceLastmod = getLastModDate('.claude-plugin/marketplace.json');
+// Generate sitemap.xml with all pages (homepage, glossary, every plugin)
 const sitemapUrls = [
-  { loc: '', priority: '1.0', lastmod: marketplaceLastmod },
-  ...marketplace.plugins.map(p => {
-    return { loc: `plugins/${p.name}/`, priority: '0.8', lastmod: marketplaceLastmod };
-  })
+  { loc: '', priority: '1.0', lastmod: MARKETPLACE_LASTMOD },
+  { loc: 'glossary/', priority: '0.6', lastmod: BUILD_DATE },
+  ...marketplace.plugins.map(p => ({ loc: `plugins/${p.name}/`, priority: '0.8', lastmod: MARKETPLACE_LASTMOD })),
 ];
 
 const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${sitemapUrls.map(url => `  <url>
-    <loc>https://2389-research.github.io/claude-plugins/${url.loc}</loc>
+    <loc>${SITE_URL}/${url.loc}</loc>
     <lastmod>${url.lastmod}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>${url.priority}</priority>
@@ -1105,20 +1117,257 @@ ${sitemapUrls.map(url => `  <url>
 </urlset>`;
 fs.writeFileSync('docs/sitemap.xml', sitemap);
 
-// Generate robots.txt
+// Markdown sitemap for AI agents that prefer plain text
+const sitemapMd = `# Sitemap
+
+Pages on this site, for AI agents and other tools that prefer markdown over XML.
+
+- [Plugin Marketplace](${SITE_URL}/) — homepage with the full plugin catalog
+- [Glossary](${SITE_URL}/glossary/) — terms used across the marketplace
+- [AGENTS.md](${SITE_URL}/AGENTS.md) — site overview for AI agents
+- [llms.txt](${SITE_URL}/llms.txt) — structured site index per llmstxt.org
+
+## Plugins
+
+${marketplace.plugins.map(p => `- [${p.name}](${SITE_URL}/plugins/${p.name}/) — ${cleanDescription(p.description)}`).join('\n')}
+`;
+fs.writeFileSync('docs/sitemap.md', sitemapMd);
+
+// robots.txt points at the live host
 const robots = `# Robots.txt for 2389 Claude Code Plugin Marketplace
 User-agent: *
 Allow: /
 
-Sitemap: https://2389-research.github.io/claude-plugins/sitemap.xml
+Sitemap: ${SITE_URL}/sitemap.xml
 Crawl-delay: 1
 `;
 fs.writeFileSync('docs/robots.txt', robots);
 
+// llms.txt per the llmstxt.org spec — structured site index for AI agents
+const llmsTxt = `# 2389 Research Claude Code Plugin Marketplace
+
+> Open source Claude Code plugins and MCP servers from 2389 Research Inc. Development workflows, testing, system administration, and AI agent capabilities. Install with one command via the Claude Code plugin marketplace.
+
+## Install the marketplace
+
+\`\`\`
+${INTERNAL_MARKETPLACE_COMMAND}
+\`\`\`
+
+${Object.values(categories).filter(c => c.plugins.length).map(cat =>
+`## ${cat.title}
+
+${cat.description}
+
+${cat.plugins.map(p => `- [${p.name}](${SITE_URL}/plugins/${p.name}/): ${cleanDescription(p.description)}`).join('\n')}`
+).join('\n\n')}
+
+## Reference
+
+- [Sitemap](${SITE_URL}/sitemap.md)
+- [Glossary](${SITE_URL}/glossary/)
+- [Source repository](https://github.com/2389-research/claude-plugins)
+- [Claude Code documentation](https://docs.claude.com/en/docs/claude-code)
+`;
+fs.writeFileSync('docs/llms.txt', llmsTxt);
+
+// AGENTS.md — site-level guide for AI agents, plus the a14y config block
+const agentsMd = `# Agents guide — 2389 Research Claude Code Plugin Marketplace
+
+This site is the official catalog of Claude Code plugins and MCP servers from 2389 Research Inc. It is generated from \`.claude-plugin/marketplace.json\` in [2389-research/claude-plugins](https://github.com/2389-research/claude-plugins).
+
+## What's here
+
+- The homepage at [${SITE_URL}/](${SITE_URL}/) lists every plugin grouped into Development, Infrastructure, Agent Systems, and Personal & Strategy.
+- Each plugin has its own page under \`/plugins/{name}/\` with the full README, install command, and source link.
+- A [glossary](${SITE_URL}/glossary/) defines marketplace-specific terms (plugin, skill, MCP server, hook, scorecard).
+- Machine-readable index files: [sitemap.xml](${SITE_URL}/sitemap.xml), [sitemap.md](${SITE_URL}/sitemap.md), [llms.txt](${SITE_URL}/llms.txt).
+- Every HTML page advertises a markdown mirror via \`<link rel="alternate" type="text/markdown" href="…/index.md">\`. Fetch the \`index.md\` URL directly for the markdown copy.
+
+## Install a plugin
+
+\`\`\`
+${INTERNAL_MARKETPLACE_COMMAND}
+/plugin install 2389-research/<plugin-name>
+\`\`\`
+
+## a14y configuration
+
+- Target URL: ${SITE_URL}/
+- Scorecard: 0.2.0
+- Mode: site
+- Last runs:
+  - ${BUILD_DATE} — baseline 67 (scorecard 0.2.0)
+`;
+fs.writeFileSync('docs/AGENTS.md', agentsMd);
+
+// Per-page markdown mirrors — homepage + every plugin
+function homepageMarkdown() {
+  const catBlocks = Object.values(categories).filter(c => c.plugins.length).map(cat =>
+`## ${cat.title}
+
+${cat.description}
+
+${cat.plugins.map(p => `- [${p.name}](${SITE_URL}/plugins/${p.name}/) — ${cleanDescription(p.description)}`).join('\n')}`
+  ).join('\n\n');
+
+  return `# 2389 Research Claude Code Plugin Marketplace
+
+> Open source Claude Code plugins and MCP servers from 2389 Research Inc.
+
+## Install
+
+\`\`\`
+${INTERNAL_MARKETPLACE_COMMAND}
+\`\`\`
+
+${catBlocks}
+
+## Reference
+
+- [AGENTS.md](${SITE_URL}/AGENTS.md)
+- [llms.txt](${SITE_URL}/llms.txt)
+- [sitemap.md](${SITE_URL}/sitemap.md)
+- [Glossary](${SITE_URL}/glossary/)
+- [Source](https://github.com/2389-research/claude-plugins)
+`;
+}
+fs.writeFileSync('docs/index.md', homepageMarkdown());
+
+function pluginMarkdown(plugin) {
+  const description = cleanDescription(plugin.description);
+  const sourceUrl = getSourceUrl(plugin);
+  const readme = getReadmeContent(plugin) || '';
+  return `# ${plugin.name}
+
+> ${description}
+
+- **Version:** ${plugin.version || '1.0.0'}
+- **Source:** ${sourceUrl}
+- **Install:** \`${getPluginInstallCommand(plugin)}\`
+
+## Install via marketplace
+
+\`\`\`
+${INTERNAL_MARKETPLACE_COMMAND}
+${getPluginInstallCommand(plugin)}
+\`\`\`
+
+## README
+
+${readme || `See ${sourceUrl} for full documentation.`}
+`;
+}
+marketplace.plugins.forEach(plugin => {
+  fs.writeFileSync(`docs/plugins/${plugin.name}/index.md`, pluginMarkdown(plugin));
+});
+
+// Glossary page (HTML + markdown mirror) — resolves html.glossary-link site-wide
+const GLOSSARY_TERMS = [
+  ['Plugin', 'A bundle of skills, slash commands, hooks, and/or MCP servers distributed as a single unit. Installed in Claude Code via <code>/plugin install</code>.'],
+  ['Skill', 'A self-contained capability — instructions plus optional supporting files — that Claude can invoke for specific tasks. Lives under <code>skills/</code> in a plugin.'],
+  ['Marketplace', 'A catalog of plugins. This site is the marketplace for 2389 Research plugins. Added in Claude Code with <code>/plugin marketplace add &lt;repo&gt;</code>.'],
+  ['MCP server', 'Model Context Protocol server. Exposes tools, resources, and prompts to Claude over a standard protocol. Some plugins ship MCP servers; others integrate with existing ones.'],
+  ['Hook', 'A shell command Claude Code executes in response to events such as tool calls or session start. Configured in <code>settings.json</code>.'],
+  ['Slash command', 'A user-invocable command typed in Claude Code as <code>/&lt;name&gt;</code>. Slash commands are defined inside skills or as standalone files in a plugin.'],
+  ['Scorecard', 'A versioned set of automated checks. The a14y scorecard, for example, rates how readable this site is for AI agents.'],
+];
+
+const glossaryStructuredData = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "DefinedTermSet",
+  "name": "Marketplace Glossary",
+  "url": `${SITE_URL}/glossary/`,
+  "datePublished": MARKETPLACE_LASTMOD,
+  "dateModified": BUILD_DATE,
+  "hasDefinedTerm": GLOSSARY_TERMS.map(([term, definition]) => ({
+    "@type": "DefinedTerm",
+    "name": term,
+    "description": definition.replace(/<[^>]+>/g, ''),
+  })),
+}, null, 2);
+
+const glossaryHtml = `<!DOCTYPE html>
+<html lang="en">
+${generateHead('Glossary', 'Marketplace-specific terms: plugin, skill, MCP server, hook, slash command, scorecard.', 'glossary/', ['glossary', 'terminology'])}
+<body>
+  <div class="grid-overlay" aria-hidden="true"></div>
+  <a href="#main-content" class="skip-link">Skip to main content</a>
+
+  ${generateNav(true)}
+
+  <header class="plugin-hero">
+    <div class="plugin-hero-inner">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a href="../">Marketplace</a>
+        <span class="breadcrumb-sep">→</span>
+        <span class="breadcrumb-current">Glossary</span>
+      </nav>
+
+      <div class="plugin-hero-header">
+        <h1 class="plugin-hero-title">Glossary</h1>
+      </div>
+
+      <p class="plugin-hero-description">Terms used across the 2389 Research plugin marketplace.</p>
+    </div>
+  </header>
+
+  <main id="main-content">
+    <section class="section readme-section">
+      <div class="section-header">
+        <span class="section-number">01</span>
+        <div class="section-title-group">
+          <h2 class="section-title">Definitions</h2>
+          <p class="section-subtitle">What things mean on this site</p>
+        </div>
+      </div>
+
+      <div class="readme-content">
+        <dl>
+${GLOSSARY_TERMS.map(([term, definition]) => `          <dt><strong>${term}</strong></dt>
+          <dd>${definition}</dd>`).join('\n')}
+        </dl>
+      </div>
+    </section>
+
+    <section class="section back-section">
+      <a href="../" class="back-link">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path d="M13 8H3M7 4L3 8l4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        Back to Marketplace
+      </a>
+    </section>
+  </main>
+
+  ${generateFooter(true)}
+
+  <script type="application/ld+json">
+  ${glossaryStructuredData}
+  </script>
+</body>
+</html>`;
+
+fs.mkdirSync('docs/glossary', { recursive: true });
+fs.writeFileSync('docs/glossary/index.html', glossaryHtml);
+
+const glossaryMd = `# Glossary
+
+Terms used across the 2389 Research plugin marketplace.
+
+${GLOSSARY_TERMS.map(([term, definition]) => `## ${term}\n\n${definition.replace(/<[^>]+>/g, '')}`).join('\n\n')}
+
+[Back to marketplace](${SITE_URL}/)
+`;
+fs.writeFileSync('docs/glossary/index.md', glossaryMd);
+
 console.log('✓ Generated docs/index.html');
 console.log(`✓ Generated ${marketplace.plugins.length} plugin pages in docs/plugins/`);
-console.log('✓ Generated docs/sitemap.xml');
+console.log('✓ Generated docs/glossary/index.html');
+console.log('✓ Generated docs/sitemap.xml + sitemap.md');
+console.log('✓ Generated docs/llms.txt + AGENTS.md');
 console.log('✓ Generated docs/robots.txt');
+console.log(`✓ Generated ${marketplace.plugins.length + 2} markdown mirrors (index.md)`);
 console.log(`✓ ${totalPlugins} plugins across ${Object.values(categories).filter(c => c.plugins.length > 0).length} categories`);
 
 // Report link conversion results


### PR DESCRIPTION
## Summary

Ran the a14y scorecard (v0.2.0) against `https://skills.2389.ai/` — baseline was **67/100** across 57 pages. Most failures cluster around one root cause: the generator hardcodes the old `2389-research.github.io/claude-plugins/` URL while the site has long since moved to `skills.2389.ai`, so the sitemap was advertising URLs that 301-redirect.

- Use a single `SITE_URL = 'https://skills.2389.ai'` constant everywhere — fixes canonical, og, twitter, JSON-LD URLs, `sitemap.xml`, and `robots.txt`. Expected to resolve `discovery.indexed` site-wide (57 pages).
- Add `dateModified` / `datePublished` to every JSON-LD block — fixes `html.json-ld.date-modified` (54 pages).
- Broaden the README link converter so any root-level `.md` reference (ROADMAP, CONTRIBUTING, ARCHITECTURE, …) is rewritten to a GitHub URL instead of breaking as a same-host relative link. Fixes 8 distinct checks × 3 pages on the journal plugin (24 failure instances).
- Advertise a markdown mirror per page via `<link rel="alternate" type="text/markdown">` and emit an `index.md` next to each `index.html`. Fixes `markdown.alternate-link` (57) and `markdown.mirror-suffix` (57).
- Add `/AGENTS.md` (with `## a14y configuration` block for re-runs), `/llms.txt` per llmstxt.org, and `/sitemap.md`. Fixes the three site-level discoverability checks.
- Add a `/glossary/` page + footer link. Fixes `html.glossary-link` (57 pages). Uses the existing `plugin-hero` and `footer-column` markup; no new CSS.

Only failing check expected to remain is `markdown.content-negotiation`, which is a server-side feature GitHub Pages can't provide.

## Test plan

- [x] `node -c scripts/generate-site.js` — no syntax errors
- [x] `npm run generate:site` — completes; 28 markdown mirrors emitted; 54 relative links converted
- [x] `node tests/generate-site-install-template.test.js` — passes
- [x] Local HTTP server: home, `/glossary/`, `/llms.txt`, `/AGENTS.md`, `/sitemap.md`, `/sitemap.xml`, `/index.md`, plugin `index.md`, plugin `index.html`, `/style.css` — all 200
- [x] Journal plugin page: previously-broken `.md` relative links now point to `github.com/.../blob/main/{ROADMAP,CONTRIBUTING,ARCHITECTURE}.md`
- [x] Spot-checked plugin page head + JSON-LD include canonical, alternate markdown link, og/twitter URLs at `skills.2389.ai`, and `dateModified`
- [ ] After merge + deploy, re-run a14y and post the new score in a comment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/claude-plugins/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Migrated marketplace to new domain (`skills.2389.ai`) with improved SEO and structured data.
  * Added comprehensive documentation for 30+ plugins with installation and usage guides.
  * Launched glossary defining key marketplace terms (Plugins, Skills, MCP servers, etc.).
  * Added AI-agent-friendly resources (llms.txt, AGENTS.md, sitemap.md) for discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/claude-plugins/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->