### PR TITLE
chore: bump simmer marketplace entry to 3.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -148,7 +148,7 @@
         "url": "https://github.com/2389-research/simmer.git"
       },
       "description": "Iterative artifact refinement with investigation-first judge board - constructs problem-specific judges that read the code, understand the problem, and propose evidence-based improvements",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "keywords": [
         "refinement",
         "iteration",


### PR DESCRIPTION
## Summary

- Bumps simmer marketplace `version` from `3.0.0` → `3.0.1`
- Pairs with [2389-research/simmer#4](https://github.com/2389-research/simmer/pull/4), which bumps the plugin manifest itself
- Forces stale plugin caches to invalidate and pick up the 2026-05-07 subdirectory fix (simmer PR #2 / commit 5c94896) that moved the orchestrator into `skills/simmer/` so sibling subskills register

Fixes [2389-research/simmer#3](https://github.com/2389-research/simmer/issues/3).

## Test plan

- [ ] After merge, fresh `/plugin install simmer@2389-research` pulls v3.0.1
- [ ] `Skill(simmer:simmer-setup)` resolves on a fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/claude-plugins/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781995433&installation_id=131176874&pr_number=34&repository=2389-research%2Fclaude-plugins&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fclaude-plugins%2Fpull%2F34&signature=bb0413c1242e2a2f70b3bbe949d9d093dec9c3c44b2520c1510d08fe6f098848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 3.0.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/claude-plugins/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->