### PR TITLE
fix: bump documentation-audit to 2.0.1 in marketplace + regen docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -207,7 +207,7 @@
         "url": "https://github.com/2389-research/documentation-audit.git"
       },
       "description": "Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "keywords": [
         "documentation",
         "audit",

--- a/docs/glossary/index.html
+++ b/docs/glossary/index.html
@@ -167,8 +167,8 @@
   "@type": "DefinedTermSet",
   "name": "Marketplace Glossary",
   "url": "https://skills.2389.ai/glossary/",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28",
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01",
   "hasDefinedTerm": [
     {
       "@type": "DefinedTerm",

--- a/docs/index.html
+++ b/docs/index.html
@@ -347,7 +347,7 @@
                 <a href="plugins/documentation-audit/" class="plugin-name-link" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="documentation-audit">
                   <h4 class="plugin-name">documentation-audit</h4>
                 </a>
-                <span class="plugin-version">v2.0.0</span>
+                <span class="plugin-version">v2.0.1</span>
               </div>
               <p class="plugin-description">Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection</p>
               <div class="plugin-tags"><span class="tag">documentation</span><span class="tag">audit</span><span class="tag">verify</span></div>
@@ -939,8 +939,8 @@
     "downloadUrl": "https://github.com/2389-research/claude-plugins",
     "softwareVersion": "1.0.0",
     "license": "https://opensource.org/licenses/MIT",
-    "datePublished": "2026-05-28",
-    "dateModified": "2026-05-28"
+    "datePublished": "2026-05-21",
+    "dateModified": "2026-06-01"
   }
   </script>
 

--- a/docs/plugins/agent-drugs/index.html
+++ b/docs/plugins/agent-drugs/index.html
@@ -404,8 +404,8 @@ npm run dev:http
   "downloadUrl": "https://github.com/2389-research/agent-drugs",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/binary-re/index.html
+++ b/docs/plugins/binary-re/index.html
@@ -381,8 +381,8 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
   "downloadUrl": "https://github.com/2389-research/binary-re",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/building-multiagent-systems/index.html
+++ b/docs/plugins/building-multiagent-systems/index.html
@@ -402,8 +402,8 @@ async function cleanup() {
   "downloadUrl": "https://github.com/2389-research/building-multiagent-systems",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/ceo-personal-os/index.html
+++ b/docs/plugins/ceo-personal-os/index.html
@@ -365,8 +365,8 @@
   "downloadUrl": "https://github.com/2389-research/ceo-personal-os",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/css-development/index.html
+++ b/docs/plugins/css-development/index.html
@@ -369,8 +369,8 @@
   "downloadUrl": "https://github.com/2389-research/css-development",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/deliberation/index.html
+++ b/docs/plugins/deliberation/index.html
@@ -384,8 +384,8 @@ Business Strategist, Developer Culture voice. Anyone to add?"
   "downloadUrl": "https://github.com/2389-research/deliberation",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/documentation-audit/index.html
+++ b/docs/plugins/documentation-audit/index.html
@@ -85,7 +85,7 @@
 
       <div class="plugin-hero-header">
         <h1 class="plugin-hero-title">documentation-audit</h1>
-        <span class="plugin-hero-version">v2.0.0</span>
+        <span class="plugin-hero-version">v2.0.1</span>
         
       </div>
 
@@ -345,10 +345,10 @@
   "description": "Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection",
   "url": "https://skills.2389.ai/plugins/documentation-audit/",
   "downloadUrl": "https://github.com/2389-research/documentation-audit",
-  "softwareVersion": "2.0.0",
+  "softwareVersion": "2.0.1",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/documentation-audit/index.md
+++ b/docs/plugins/documentation-audit/index.md
@@ -2,7 +2,7 @@
 
 > Verify documentation claims against codebase reality - two-pass extraction with pattern expansion for comprehensive drift detection
 
-- **Version:** 2.0.0
+- **Version:** 2.0.1
 - **Source:** https://github.com/2389-research/documentation-audit
 
 ## Install

--- a/docs/plugins/firebase-development/index.html
+++ b/docs/plugins/firebase-development/index.html
@@ -367,8 +367,8 @@ export const users = {
   "downloadUrl": "https://github.com/2389-research/firebase-development",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/fresh-eyes-review/index.html
+++ b/docs/plugins/fresh-eyes-review/index.html
@@ -373,8 +373,8 @@
   "downloadUrl": "https://github.com/2389-research/fresh-eyes-review",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/git-repo-prep/index.html
+++ b/docs/plugins/git-repo-prep/index.html
@@ -369,8 +369,8 @@
   "downloadUrl": "https://github.com/2389-research/git-repo-prep",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/jam/index.html
+++ b/docs/plugins/jam/index.html
@@ -409,8 +409,8 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
   "downloadUrl": "https://github.com/2389-research/jam",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/journal/index.html
+++ b/docs/plugins/journal/index.html
@@ -492,8 +492,8 @@ Vector embeddings provide semantic understanding...
   "downloadUrl": "https://github.com/2389-research/journal-mcp",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/landing-page-design/index.html
+++ b/docs/plugins/landing-page-design/index.html
@@ -388,8 +388,8 @@ Full animation system for entrances, continuous effects, interactions, and decor
   "downloadUrl": "https://github.com/2389-research/landing-page-design",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/prbuddy/index.html
+++ b/docs/plugins/prbuddy/index.html
@@ -347,8 +347,8 @@
   "downloadUrl": "https://github.com/2389-research/prbuddy",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/remote-system-maintenance/index.html
+++ b/docs/plugins/remote-system-maintenance/index.html
@@ -394,8 +394,8 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
   "downloadUrl": "https://github.com/2389-research/remote-system-maintenance",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/review-squad/index.html
+++ b/docs/plugins/review-squad/index.html
@@ -393,8 +393,8 @@ things professional reviewers skip because they're too polite.
   "downloadUrl": "https://github.com/2389-research/review-squad",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/scenario-testing/index.html
+++ b/docs/plugins/scenario-testing/index.html
@@ -417,8 +417,8 @@ def test_user_registration_scenario():
   "downloadUrl": "https://github.com/2389-research/scenario-testing",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/simmer/index.html
+++ b/docs/plugins/simmer/index.html
@@ -451,8 +451,8 @@ docs/simmer/                   # Tracking files (separate from workspace)
   "downloadUrl": "https://github.com/2389-research/simmer",
   "softwareVersion": "3.0.1",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/slack-mcp/index.html
+++ b/docs/plugins/slack-mcp/index.html
@@ -406,8 +406,8 @@ npm start
   "downloadUrl": "https://github.com/2389-research/slack-mcp",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/socialmedia/index.html
+++ b/docs/plugins/socialmedia/index.html
@@ -391,8 +391,8 @@ docker-compose up -d
   "downloadUrl": "https://github.com/2389-research/mcp-socialmedia",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/speed-run/index.html
+++ b/docs/plugins/speed-run/index.html
@@ -429,8 +429,8 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
   "downloadUrl": "https://github.com/2389-research/speed-run",
   "softwareVersion": "1.1.1",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/summarize-meetings/index.html
+++ b/docs/plugins/summarize-meetings/index.html
@@ -354,8 +354,8 @@
   "downloadUrl": "https://github.com/2389-research/summarize-meetings",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/terminal-title/index.html
+++ b/docs/plugins/terminal-title/index.html
@@ -368,8 +368,8 @@ export TERMINAL_TITLE_EMOJI=💼
   "downloadUrl": "https://github.com/2389-research/terminal-title",
   "softwareVersion": "1.1.2",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/test-kitchen/index.html
+++ b/docs/plugins/test-kitchen/index.html
@@ -439,8 +439,8 @@ Which approach?
   "downloadUrl": "https://github.com/2389-research/test-kitchen",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/worldview-synthesis/index.html
+++ b/docs/plugins/worldview-synthesis/index.html
@@ -376,8 +376,8 @@ Find the cracks. Leave no trace.
   "downloadUrl": "https://github.com/2389-research/worldview-synthesis",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/xtool/index.html
+++ b/docs/plugins/xtool/index.html
@@ -370,8 +370,8 @@ xtool dev
   "downloadUrl": "https://github.com/2389-research/xtool",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,169 +2,169 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://skills.2389.ai/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/glossary/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/css-development/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/firebase-development/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/landing-page-design/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/xtool/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/building-multiagent-systems/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/speed-run/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/test-kitchen/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/simmer/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/scenario-testing/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/fresh-eyes-review/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/documentation-audit/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/ceo-personal-os/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/worldview-synthesis/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/deliberation/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/terminal-title/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/slack-mcp/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/remote-system-maintenance/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/binary-re/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/review-squad/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/git-repo-prep/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/prbuddy/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/summarize-meetings/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/jam/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/agent-drugs/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/socialmedia/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/journal/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
Closes #38.

The `documentation-audit` plugin shipped bugfix release **v2.0.1** (`agent: Plan` → `agent: general-purpose`, restoring Write/Edit/Agent while keeping `context: fork`). This marketplace still advertised 2.0.0.

### What this does
- Bumps **only** the `documentation-audit` entry in `.claude-plugin/marketplace.json` to `2.0.1` (top-level `metadata.version` left untouched).
- Regenerates the site via `npm run generate:site` — the doc-audit page now shows `2.0.1` in the header, hero badge, and JSON-LD `softwareVersion`.

### Verification
- Confirmed upstream **v2.0.1** exists: tag `a088648`, published 2026-06-01, release notes match the issue.
- `grep -rn '2\.0\.0' docs/plugins/documentation-audit/` → no matches.
- Other plugins' versions untouched.
- `npm test` passes.

> Note: the generator also recomputes `datePublished`/`dateModified`/sitemap `lastmod` from git history each run, so the diff includes date-only churn across other pages — no content changes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/claude-plugins/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782925267&installation_id=131176874&pr_number=39&repository=2389-research%2Fclaude-plugins&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fclaude-plugins%2Fpull%2F39&signature=bcbd325ed56385ed62172e186d7bbca444b653edd239ba5df1bf8491052b69a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation-audit plugin to v2.0.1
  * Refreshed metadata timestamps across plugin documentation pages and site resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->