### PR TITLE
fix: rename marketplace to 2389-research so documented install resolves (#32)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "2389-research-marketplace",
+  "name": "2389-research",
   "owner": {
     "name": "2389 Research Inc",
     "email": "hello@2389.ai",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ git commit -m "feat: add my-plugin to marketplace"
 
 ```json
 {
-  "name": "2389-research-marketplace",
+  "name": "2389-research",
   "owner": {
     "name": "2389 Research Inc",
     "email": "hello@2389.ai",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or natively in Claude Code:
 ```bash
 # Add the marketplace, then install any plugin
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/simmer
+/plugin install simmer@2389-research
 ```
 
 > The 4 MCP servers (journal, socialmedia, slack-mcp, agent-drugs) install via Claude Code only — they ship no skills for npx.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,7 +22,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/<plugin-name>
+/plugin install <plugin-name>@2389-research
 ```
 
 (MCP servers — slack-mcp, agent-drugs, socialmedia, journal — install via Claude Code only; they ship no skills for npx.)

--- a/docs/glossary/index.html
+++ b/docs/glossary/index.html
@@ -167,7 +167,7 @@
   "@type": "DefinedTermSet",
   "name": "Marketplace Glossary",
   "url": "https://skills.2389.ai/glossary/",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01",
   "hasDefinedTerm": [
     {

--- a/docs/glossary/index.html
+++ b/docs/glossary/index.html
@@ -167,8 +167,8 @@
   "@type": "DefinedTermSet",
   "name": "Marketplace Glossary",
   "url": "https://skills.2389.ai/glossary/",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28",
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01",
   "hasDefinedTerm": [
     {
       "@type": "DefinedTerm",

--- a/docs/index.html
+++ b/docs/index.html
@@ -939,7 +939,7 @@
     "downloadUrl": "https://github.com/2389-research/claude-plugins",
     "softwareVersion": "1.0.0",
     "license": "https://opensource.org/licenses/MIT",
-    "datePublished": "2026-05-21",
+    "datePublished": "2026-06-01",
     "dateModified": "2026-06-01"
   }
   </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -160,7 +160,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-css-development" aria-controls="panel-cc-card-css-development" id="tab-cc-card-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-css-development" aria-labelledby="tab-npx-card-css-development" data-panel="npx-card-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-css-development" aria-labelledby="tab-cc-card-css-development" data-panel="cc-card-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-css-development" aria-labelledby="tab-cc-card-css-development" data-panel="cc-card-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
                 <a href="plugins/css-development/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="css-development">Details →</a>
               </div>
@@ -182,7 +182,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-firebase-development" aria-controls="panel-cc-card-firebase-development" id="tab-cc-card-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-firebase-development" aria-labelledby="tab-npx-card-firebase-development" data-panel="npx-card-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-firebase-development" aria-labelledby="tab-cc-card-firebase-development" data-panel="cc-card-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-firebase-development" aria-labelledby="tab-cc-card-firebase-development" data-panel="cc-card-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
                 <a href="plugins/firebase-development/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="firebase-development">Details →</a>
               </div>
@@ -204,7 +204,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-landing-page-design" aria-controls="panel-cc-card-landing-page-design" id="tab-cc-card-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-landing-page-design" aria-labelledby="tab-npx-card-landing-page-design" data-panel="npx-card-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-landing-page-design" aria-labelledby="tab-cc-card-landing-page-design" data-panel="cc-card-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-landing-page-design" aria-labelledby="tab-cc-card-landing-page-design" data-panel="cc-card-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
                 <a href="plugins/landing-page-design/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="landing-page-design">Details →</a>
               </div>
@@ -226,7 +226,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-xtool" aria-controls="panel-cc-card-xtool" id="tab-cc-card-xtool">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-xtool" aria-labelledby="tab-npx-card-xtool" data-panel="npx-card-xtool"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool-npx">npx skills add 2389-research/xtool</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-xtool" aria-labelledby="tab-cc-card-xtool" data-panel="cc-card-xtool" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool">/plugin install 2389-research/xtool</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-xtool" aria-labelledby="tab-cc-card-xtool" data-panel="cc-card-xtool" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool">/plugin install xtool@2389-research</code></div>
           </div>
                 <a href="plugins/xtool/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="xtool">Details →</a>
               </div>
@@ -248,7 +248,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-speed-run" aria-controls="panel-cc-card-speed-run" id="tab-cc-card-speed-run">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-speed-run" aria-labelledby="tab-npx-card-speed-run" data-panel="npx-card-speed-run"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="speed-run-npx">npx skills add 2389-research/speed-run</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-speed-run" aria-labelledby="tab-cc-card-speed-run" data-panel="cc-card-speed-run" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="speed-run">/plugin install 2389-research/speed-run</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-speed-run" aria-labelledby="tab-cc-card-speed-run" data-panel="cc-card-speed-run" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="speed-run">/plugin install speed-run@2389-research</code></div>
           </div>
                 <a href="plugins/speed-run/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="speed-run">Details →</a>
               </div>
@@ -270,7 +270,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-test-kitchen" aria-controls="panel-cc-card-test-kitchen" id="tab-cc-card-test-kitchen">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-test-kitchen" aria-labelledby="tab-npx-card-test-kitchen" data-panel="npx-card-test-kitchen"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="test-kitchen-npx">npx skills add 2389-research/test-kitchen</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-test-kitchen" aria-labelledby="tab-cc-card-test-kitchen" data-panel="cc-card-test-kitchen" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="test-kitchen">/plugin install 2389-research/test-kitchen</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-test-kitchen" aria-labelledby="tab-cc-card-test-kitchen" data-panel="cc-card-test-kitchen" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="test-kitchen">/plugin install test-kitchen@2389-research</code></div>
           </div>
                 <a href="plugins/test-kitchen/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="test-kitchen">Details →</a>
               </div>
@@ -292,7 +292,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-simmer" aria-controls="panel-cc-card-simmer" id="tab-cc-card-simmer">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-simmer" aria-labelledby="tab-npx-card-simmer" data-panel="npx-card-simmer"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="simmer-npx">npx skills add 2389-research/simmer</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-simmer" aria-labelledby="tab-cc-card-simmer" data-panel="cc-card-simmer" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="simmer">/plugin install 2389-research/simmer</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-simmer" aria-labelledby="tab-cc-card-simmer" data-panel="cc-card-simmer" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="simmer">/plugin install simmer@2389-research</code></div>
           </div>
                 <a href="plugins/simmer/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="simmer">Details →</a>
               </div>
@@ -314,7 +314,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-scenario-testing" aria-controls="panel-cc-card-scenario-testing" id="tab-cc-card-scenario-testing">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-scenario-testing" aria-labelledby="tab-npx-card-scenario-testing" data-panel="npx-card-scenario-testing"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="scenario-testing-npx">npx skills add 2389-research/scenario-testing</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-scenario-testing" aria-labelledby="tab-cc-card-scenario-testing" data-panel="cc-card-scenario-testing" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="scenario-testing">/plugin install 2389-research/scenario-testing</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-scenario-testing" aria-labelledby="tab-cc-card-scenario-testing" data-panel="cc-card-scenario-testing" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="scenario-testing">/plugin install scenario-testing@2389-research</code></div>
           </div>
                 <a href="plugins/scenario-testing/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="scenario-testing">Details →</a>
               </div>
@@ -336,7 +336,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-fresh-eyes-review" aria-controls="panel-cc-card-fresh-eyes-review" id="tab-cc-card-fresh-eyes-review">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-fresh-eyes-review" aria-labelledby="tab-npx-card-fresh-eyes-review" data-panel="npx-card-fresh-eyes-review"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="fresh-eyes-review-npx">npx skills add 2389-research/fresh-eyes-review</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-fresh-eyes-review" aria-labelledby="tab-cc-card-fresh-eyes-review" data-panel="cc-card-fresh-eyes-review" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="fresh-eyes-review">/plugin install 2389-research/fresh-eyes-review</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-fresh-eyes-review" aria-labelledby="tab-cc-card-fresh-eyes-review" data-panel="cc-card-fresh-eyes-review" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="fresh-eyes-review">/plugin install fresh-eyes-review@2389-research</code></div>
           </div>
                 <a href="plugins/fresh-eyes-review/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="fresh-eyes-review">Details →</a>
               </div>
@@ -358,7 +358,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-documentation-audit" aria-controls="panel-cc-card-documentation-audit" id="tab-cc-card-documentation-audit">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-documentation-audit" aria-labelledby="tab-npx-card-documentation-audit" data-panel="npx-card-documentation-audit"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="documentation-audit-npx">npx skills add 2389-research/documentation-audit</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-documentation-audit" aria-labelledby="tab-cc-card-documentation-audit" data-panel="cc-card-documentation-audit" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="documentation-audit">/plugin install 2389-research/documentation-audit</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-documentation-audit" aria-labelledby="tab-cc-card-documentation-audit" data-panel="cc-card-documentation-audit" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="documentation-audit">/plugin install documentation-audit@2389-research</code></div>
           </div>
                 <a href="plugins/documentation-audit/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="documentation-audit">Details →</a>
               </div>
@@ -374,7 +374,7 @@
               <p class="plugin-description">Slack workspace integration MCP server - create channels, invite users, post messages, manage threads for team collaboration</p>
               <div class="plugin-tags"><span class="tag">slack</span><span class="tag">mcp</span><span class="tag">messaging</span></div>
               <div class="plugin-footer">
-                <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="slack-mcp">/plugin install 2389-research/slack-mcp</code>
+                <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="slack-mcp">/plugin install slack-mcp@2389-research</code>
                 <a href="plugins/slack-mcp/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="slack-mcp">Details →</a>
               </div>
             </article>
@@ -395,7 +395,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-git-repo-prep" aria-controls="panel-cc-card-git-repo-prep" id="tab-cc-card-git-repo-prep">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-git-repo-prep" aria-labelledby="tab-npx-card-git-repo-prep" data-panel="npx-card-git-repo-prep"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="git-repo-prep-npx">npx skills add 2389-research/git-repo-prep</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-git-repo-prep" aria-labelledby="tab-cc-card-git-repo-prep" data-panel="cc-card-git-repo-prep" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="git-repo-prep">/plugin install 2389-research/git-repo-prep</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-git-repo-prep" aria-labelledby="tab-cc-card-git-repo-prep" data-panel="cc-card-git-repo-prep" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="git-repo-prep">/plugin install git-repo-prep@2389-research</code></div>
           </div>
                 <a href="plugins/git-repo-prep/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="git-repo-prep">Details →</a>
               </div>
@@ -417,7 +417,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-prbuddy" aria-controls="panel-cc-card-prbuddy" id="tab-cc-card-prbuddy">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-prbuddy" aria-labelledby="tab-npx-card-prbuddy" data-panel="npx-card-prbuddy"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="prbuddy-npx">npx skills add 2389-research/prbuddy</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-prbuddy" aria-labelledby="tab-cc-card-prbuddy" data-panel="cc-card-prbuddy" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="prbuddy">/plugin install 2389-research/prbuddy</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-prbuddy" aria-labelledby="tab-cc-card-prbuddy" data-panel="cc-card-prbuddy" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="prbuddy">/plugin install prbuddy@2389-research</code></div>
           </div>
                 <a href="plugins/prbuddy/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="prbuddy">Details →</a>
               </div>
@@ -433,7 +433,7 @@
               <p class="plugin-description">Digital drugs that modify AI behavior through prompt injection</p>
               <div class="plugin-tags"><span class="tag">behavior</span><span class="tag">prompts</span><span class="tag">modification</span></div>
               <div class="plugin-footer">
-                <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="agent-drugs">/plugin install 2389-research/agent-drugs</code>
+                <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="agent-drugs">/plugin install agent-drugs@2389-research</code>
                 <a href="plugins/agent-drugs/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="agent-drugs">Details →</a>
               </div>
             </article>
@@ -468,7 +468,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-terminal-title" aria-controls="panel-cc-card-terminal-title" id="tab-cc-card-terminal-title">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-terminal-title" aria-labelledby="tab-npx-card-terminal-title" data-panel="npx-card-terminal-title"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title-npx">npx skills add 2389-research/terminal-title</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-terminal-title" aria-labelledby="tab-cc-card-terminal-title" data-panel="cc-card-terminal-title" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title">/plugin install 2389-research/terminal-title</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-terminal-title" aria-labelledby="tab-cc-card-terminal-title" data-panel="cc-card-terminal-title" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title">/plugin install terminal-title@2389-research</code></div>
           </div>
                 <a href="plugins/terminal-title/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="terminal-title">Details →</a>
               </div>
@@ -490,7 +490,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-remote-system-maintenance" aria-controls="panel-cc-card-remote-system-maintenance" id="tab-cc-card-remote-system-maintenance">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-remote-system-maintenance" aria-labelledby="tab-npx-card-remote-system-maintenance" data-panel="npx-card-remote-system-maintenance"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance-npx">npx skills add 2389-research/remote-system-maintenance</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-remote-system-maintenance" aria-labelledby="tab-cc-card-remote-system-maintenance" data-panel="cc-card-remote-system-maintenance" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance">/plugin install 2389-research/remote-system-maintenance</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-remote-system-maintenance" aria-labelledby="tab-cc-card-remote-system-maintenance" data-panel="cc-card-remote-system-maintenance" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance">/plugin install remote-system-maintenance@2389-research</code></div>
           </div>
                 <a href="plugins/remote-system-maintenance/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="remote-system-maintenance">Details →</a>
               </div>
@@ -512,7 +512,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-binary-re" aria-controls="panel-cc-card-binary-re" id="tab-cc-card-binary-re">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-binary-re" aria-labelledby="tab-npx-card-binary-re" data-panel="npx-card-binary-re"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re-npx">npx skills add 2389-research/binary-re</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-binary-re" aria-labelledby="tab-cc-card-binary-re" data-panel="cc-card-binary-re" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re">/plugin install 2389-research/binary-re</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-binary-re" aria-labelledby="tab-cc-card-binary-re" data-panel="cc-card-binary-re" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re">/plugin install binary-re@2389-research</code></div>
           </div>
                 <a href="plugins/binary-re/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="binary-re">Details →</a>
               </div>
@@ -548,7 +548,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-building-multiagent-systems" aria-controls="panel-cc-card-building-multiagent-systems" id="tab-cc-card-building-multiagent-systems">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-building-multiagent-systems" aria-labelledby="tab-npx-card-building-multiagent-systems" data-panel="npx-card-building-multiagent-systems"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems-npx">npx skills add 2389-research/building-multiagent-systems</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-building-multiagent-systems" aria-labelledby="tab-cc-card-building-multiagent-systems" data-panel="cc-card-building-multiagent-systems" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install 2389-research/building-multiagent-systems</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-building-multiagent-systems" aria-labelledby="tab-cc-card-building-multiagent-systems" data-panel="cc-card-building-multiagent-systems" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install building-multiagent-systems@2389-research</code></div>
           </div>
                 <a href="plugins/building-multiagent-systems/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="building-multiagent-systems">Details →</a>
               </div>
@@ -570,7 +570,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-deliberation" aria-controls="panel-cc-card-deliberation" id="tab-cc-card-deliberation">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-deliberation" aria-labelledby="tab-npx-card-deliberation" data-panel="npx-card-deliberation"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation-npx">npx skills add 2389-research/deliberation</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-deliberation" aria-labelledby="tab-cc-card-deliberation" data-panel="cc-card-deliberation" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install 2389-research/deliberation</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-deliberation" aria-labelledby="tab-cc-card-deliberation" data-panel="cc-card-deliberation" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install deliberation@2389-research</code></div>
           </div>
                 <a href="plugins/deliberation/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="deliberation">Details →</a>
               </div>
@@ -592,7 +592,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-review-squad" aria-controls="panel-cc-card-review-squad" id="tab-cc-card-review-squad">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-review-squad" aria-labelledby="tab-npx-card-review-squad" data-panel="npx-card-review-squad"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad-npx">npx skills add 2389-research/review-squad</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-review-squad" aria-labelledby="tab-cc-card-review-squad" data-panel="cc-card-review-squad" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install 2389-research/review-squad</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-review-squad" aria-labelledby="tab-cc-card-review-squad" data-panel="cc-card-review-squad" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install review-squad@2389-research</code></div>
           </div>
                 <a href="plugins/review-squad/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="review-squad">Details →</a>
               </div>
@@ -614,7 +614,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-jam" aria-controls="panel-cc-card-jam" id="tab-cc-card-jam">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-jam" aria-labelledby="tab-npx-card-jam" data-panel="npx-card-jam"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam-npx">npx skills add 2389-research/jam</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-jam" aria-labelledby="tab-cc-card-jam" data-panel="cc-card-jam" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">/plugin install 2389-research/jam</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-jam" aria-labelledby="tab-cc-card-jam" data-panel="cc-card-jam" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">/plugin install jam@2389-research</code></div>
           </div>
                 <a href="plugins/jam/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="jam">Details →</a>
               </div>
@@ -630,7 +630,7 @@
               <p class="plugin-description">A server that provides social media functionality for AI agents, enabling them to interact in team-based discussions.</p>
               <div class="plugin-tags"><span class="tag">social-media</span><span class="tag">communication</span><span class="tag">team-discussion</span></div>
               <div class="plugin-footer">
-                <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="socialmedia">/plugin install 2389-research/socialmedia</code>
+                <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="socialmedia">/plugin install socialmedia@2389-research</code>
                 <a href="plugins/socialmedia/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="socialmedia">Details →</a>
               </div>
             </article>
@@ -665,7 +665,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-ceo-personal-os" aria-controls="panel-cc-card-ceo-personal-os" id="tab-cc-card-ceo-personal-os">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-ceo-personal-os" aria-labelledby="tab-npx-card-ceo-personal-os" data-panel="npx-card-ceo-personal-os"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os-npx">npx skills add 2389-research/ceo-personal-os</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-ceo-personal-os" aria-labelledby="tab-cc-card-ceo-personal-os" data-panel="cc-card-ceo-personal-os" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">/plugin install 2389-research/ceo-personal-os</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-ceo-personal-os" aria-labelledby="tab-cc-card-ceo-personal-os" data-panel="cc-card-ceo-personal-os" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">/plugin install ceo-personal-os@2389-research</code></div>
           </div>
                 <a href="plugins/ceo-personal-os/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="ceo-personal-os">Details →</a>
               </div>
@@ -687,7 +687,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-worldview-synthesis" aria-controls="panel-cc-card-worldview-synthesis" id="tab-cc-card-worldview-synthesis">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-worldview-synthesis" aria-labelledby="tab-npx-card-worldview-synthesis" data-panel="npx-card-worldview-synthesis"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis-npx">npx skills add 2389-research/worldview-synthesis</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-worldview-synthesis" aria-labelledby="tab-cc-card-worldview-synthesis" data-panel="cc-card-worldview-synthesis" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">/plugin install 2389-research/worldview-synthesis</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-worldview-synthesis" aria-labelledby="tab-cc-card-worldview-synthesis" data-panel="cc-card-worldview-synthesis" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">/plugin install worldview-synthesis@2389-research</code></div>
           </div>
                 <a href="plugins/worldview-synthesis/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="worldview-synthesis">Details →</a>
               </div>
@@ -709,7 +709,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-card-summarize-meetings" aria-controls="panel-cc-card-summarize-meetings" id="tab-cc-card-summarize-meetings">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-card-summarize-meetings" aria-labelledby="tab-npx-card-summarize-meetings" data-panel="npx-card-summarize-meetings"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings-npx">npx skills add 2389-research/summarize-meetings</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-summarize-meetings" aria-labelledby="tab-cc-card-summarize-meetings" data-panel="cc-card-summarize-meetings" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">/plugin install 2389-research/summarize-meetings</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-card-summarize-meetings" aria-labelledby="tab-cc-card-summarize-meetings" data-panel="cc-card-summarize-meetings" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">/plugin install summarize-meetings@2389-research</code></div>
           </div>
                 <a href="plugins/summarize-meetings/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="summarize-meetings">Details →</a>
               </div>
@@ -725,7 +725,7 @@
               <p class="plugin-description">A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts</p>
               <div class="plugin-tags"><span class="tag">journal</span><span class="tag">journaling</span><span class="tag">thoughts</span></div>
               <div class="plugin-footer">
-                <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="journal">/plugin install 2389-research/journal</code>
+                <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="journal">/plugin install journal@2389-research</code>
                 <a href="plugins/journal/" class="plugin-source" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="journal">Details →</a>
               </div>
             </article>
@@ -806,7 +806,7 @@
               <span class="step-number">2</span>
               <div class="step-content">
                 <span class="step-label">Grab what you need</span>
-                <code>/plugin install 2389-research/better-dev</code>
+                <code>/plugin install better-dev@2389-research</code>
               </div>
             </div>
             <div class="step">
@@ -939,8 +939,8 @@
     "downloadUrl": "https://github.com/2389-research/claude-plugins",
     "softwareVersion": "1.0.0",
     "license": "https://opensource.org/licenses/MIT",
-    "datePublished": "2026-05-28",
-    "dateModified": "2026-05-28"
+    "datePublished": "2026-05-21",
+    "dateModified": "2026-06-01"
   }
   </script>
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -14,7 +14,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/<plugin>
+/plugin install <plugin>@2389-research
 ```
 
 ## Development

--- a/docs/plugins/agent-drugs/index.html
+++ b/docs/plugins/agent-drugs/index.html
@@ -404,7 +404,7 @@ npm run dev:http
   "downloadUrl": "https://github.com/2389-research/agent-drugs",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/agent-drugs/index.html
+++ b/docs/plugins/agent-drugs/index.html
@@ -96,7 +96,7 @@
       <div class="plugin-hero-actions">
         <div class="install-block">
           <span class="install-label">Install</span>
-          <code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="agent-drugs">/plugin install 2389-research/agent-drugs</code>
+          <code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="agent-drugs">/plugin install agent-drugs@2389-research</code>
         </div>
         <a href="https://github.com/2389-research/agent-drugs" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="agent-drugs">
           View Source
@@ -246,7 +246,7 @@ npm run dev:http
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="agent-drugs-install">/plugin install 2389-research/agent-drugs</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="agent-drugs-install">/plugin install agent-drugs@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -287,7 +287,7 @@ npm run dev:http
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -309,7 +309,7 @@ npm run dev:http
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -331,7 +331,7 @@ npm run dev:http
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -404,8 +404,8 @@ npm run dev:http
   "downloadUrl": "https://github.com/2389-research/agent-drugs",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/agent-drugs/index.md
+++ b/docs/plugins/agent-drugs/index.md
@@ -11,7 +11,7 @@ This is an MCP server — install it in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/agent-drugs
+/plugin install agent-drugs@2389-research
 ```
 
 ## README

--- a/docs/plugins/binary-re/index.html
+++ b/docs/plugins/binary-re/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-binary-re" aria-controls="panel-cc-binary-re" id="tab-cc-binary-re">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-binary-re" aria-labelledby="tab-npx-binary-re" data-panel="npx-binary-re"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re-npx">npx skills add 2389-research/binary-re</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-binary-re" aria-labelledby="tab-cc-binary-re" data-panel="cc-binary-re" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re">/plugin install 2389-research/binary-re</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-binary-re" aria-labelledby="tab-cc-binary-re" data-panel="cc-binary-re" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re">/plugin install binary-re@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/binary-re" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="binary-re">
@@ -244,7 +244,7 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="binary-re-install">/plugin install 2389-research/binary-re</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="binary-re-install">/plugin install binary-re@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -286,7 +286,7 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-terminal-title" aria-controls="panel-cc-related-terminal-title" id="tab-cc-related-terminal-title">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-terminal-title" aria-labelledby="tab-npx-related-terminal-title" data-panel="npx-related-terminal-title"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title-npx">npx skills add 2389-research/terminal-title</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-terminal-title" aria-labelledby="tab-cc-related-terminal-title" data-panel="cc-related-terminal-title" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title">/plugin install 2389-research/terminal-title</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-terminal-title" aria-labelledby="tab-cc-related-terminal-title" data-panel="cc-related-terminal-title" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title">/plugin install terminal-title@2389-research</code></div>
           </div>
             <a href="../terminal-title/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="terminal-title">Details →</a>
           </div>
@@ -308,7 +308,7 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-remote-system-maintenance" aria-controls="panel-cc-related-remote-system-maintenance" id="tab-cc-related-remote-system-maintenance">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-remote-system-maintenance" aria-labelledby="tab-npx-related-remote-system-maintenance" data-panel="npx-related-remote-system-maintenance"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance-npx">npx skills add 2389-research/remote-system-maintenance</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-remote-system-maintenance" aria-labelledby="tab-cc-related-remote-system-maintenance" data-panel="cc-related-remote-system-maintenance" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance">/plugin install 2389-research/remote-system-maintenance</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-remote-system-maintenance" aria-labelledby="tab-cc-related-remote-system-maintenance" data-panel="cc-related-remote-system-maintenance" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance">/plugin install remote-system-maintenance@2389-research</code></div>
           </div>
             <a href="../remote-system-maintenance/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="remote-system-maintenance">Details →</a>
           </div>
@@ -381,8 +381,8 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
   "downloadUrl": "https://github.com/2389-research/binary-re",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/binary-re/index.html
+++ b/docs/plugins/binary-re/index.html
@@ -381,7 +381,7 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
   "downloadUrl": "https://github.com/2389-research/binary-re",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/binary-re/index.md
+++ b/docs/plugins/binary-re/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/binary-re
+/plugin install binary-re@2389-research
 ```
 
 ## README

--- a/docs/plugins/building-multiagent-systems/index.html
+++ b/docs/plugins/building-multiagent-systems/index.html
@@ -402,7 +402,7 @@ async function cleanup() {
   "downloadUrl": "https://github.com/2389-research/building-multiagent-systems",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/building-multiagent-systems/index.html
+++ b/docs/plugins/building-multiagent-systems/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-building-multiagent-systems" aria-controls="panel-cc-building-multiagent-systems" id="tab-cc-building-multiagent-systems">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-building-multiagent-systems" aria-labelledby="tab-npx-building-multiagent-systems" data-panel="npx-building-multiagent-systems"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems-npx">npx skills add 2389-research/building-multiagent-systems</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-building-multiagent-systems" aria-labelledby="tab-cc-building-multiagent-systems" data-panel="cc-building-multiagent-systems" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install 2389-research/building-multiagent-systems</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-building-multiagent-systems" aria-labelledby="tab-cc-building-multiagent-systems" data-panel="cc-building-multiagent-systems" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install building-multiagent-systems@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/building-multiagent-systems" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="building-multiagent-systems">
@@ -243,7 +243,7 @@ async function cleanup() {
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="building-multiagent-systems-install">/plugin install 2389-research/building-multiagent-systems</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="building-multiagent-systems-install">/plugin install building-multiagent-systems@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -285,7 +285,7 @@ async function cleanup() {
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-deliberation" aria-controls="panel-cc-related-deliberation" id="tab-cc-related-deliberation">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-deliberation" aria-labelledby="tab-npx-related-deliberation" data-panel="npx-related-deliberation"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation-npx">npx skills add 2389-research/deliberation</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-deliberation" aria-labelledby="tab-cc-related-deliberation" data-panel="cc-related-deliberation" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install 2389-research/deliberation</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-deliberation" aria-labelledby="tab-cc-related-deliberation" data-panel="cc-related-deliberation" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install deliberation@2389-research</code></div>
           </div>
             <a href="../deliberation/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="deliberation">Details →</a>
           </div>
@@ -307,7 +307,7 @@ async function cleanup() {
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-review-squad" aria-controls="panel-cc-related-review-squad" id="tab-cc-related-review-squad">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-review-squad" aria-labelledby="tab-npx-related-review-squad" data-panel="npx-related-review-squad"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad-npx">npx skills add 2389-research/review-squad</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-review-squad" aria-labelledby="tab-cc-related-review-squad" data-panel="cc-related-review-squad" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install 2389-research/review-squad</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-review-squad" aria-labelledby="tab-cc-related-review-squad" data-panel="cc-related-review-squad" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install review-squad@2389-research</code></div>
           </div>
             <a href="../review-squad/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="review-squad">Details →</a>
           </div>
@@ -329,7 +329,7 @@ async function cleanup() {
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-jam" aria-controls="panel-cc-related-jam" id="tab-cc-related-jam">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-jam" aria-labelledby="tab-npx-related-jam" data-panel="npx-related-jam"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam-npx">npx skills add 2389-research/jam</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-jam" aria-labelledby="tab-cc-related-jam" data-panel="cc-related-jam" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">/plugin install 2389-research/jam</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-jam" aria-labelledby="tab-cc-related-jam" data-panel="cc-related-jam" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">/plugin install jam@2389-research</code></div>
           </div>
             <a href="../jam/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="jam">Details →</a>
           </div>
@@ -402,8 +402,8 @@ async function cleanup() {
   "downloadUrl": "https://github.com/2389-research/building-multiagent-systems",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/building-multiagent-systems/index.md
+++ b/docs/plugins/building-multiagent-systems/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/building-multiagent-systems
+/plugin install building-multiagent-systems@2389-research
 ```
 
 ## README

--- a/docs/plugins/ceo-personal-os/index.html
+++ b/docs/plugins/ceo-personal-os/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-ceo-personal-os" aria-controls="panel-cc-ceo-personal-os" id="tab-cc-ceo-personal-os">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-ceo-personal-os" aria-labelledby="tab-npx-ceo-personal-os" data-panel="npx-ceo-personal-os"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os-npx">npx skills add 2389-research/ceo-personal-os</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-ceo-personal-os" aria-labelledby="tab-cc-ceo-personal-os" data-panel="cc-ceo-personal-os" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">/plugin install 2389-research/ceo-personal-os</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-ceo-personal-os" aria-labelledby="tab-cc-ceo-personal-os" data-panel="cc-ceo-personal-os" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">/plugin install ceo-personal-os@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/ceo-personal-os" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="ceo-personal-os">
@@ -213,7 +213,7 @@
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="ceo-personal-os-install">/plugin install 2389-research/ceo-personal-os</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="ceo-personal-os-install">/plugin install ceo-personal-os@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -255,7 +255,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-worldview-synthesis" aria-controls="panel-cc-related-worldview-synthesis" id="tab-cc-related-worldview-synthesis">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-worldview-synthesis" aria-labelledby="tab-npx-related-worldview-synthesis" data-panel="npx-related-worldview-synthesis"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis-npx">npx skills add 2389-research/worldview-synthesis</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-worldview-synthesis" aria-labelledby="tab-cc-related-worldview-synthesis" data-panel="cc-related-worldview-synthesis" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">/plugin install 2389-research/worldview-synthesis</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-worldview-synthesis" aria-labelledby="tab-cc-related-worldview-synthesis" data-panel="cc-related-worldview-synthesis" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">/plugin install worldview-synthesis@2389-research</code></div>
           </div>
             <a href="../worldview-synthesis/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="worldview-synthesis">Details →</a>
           </div>
@@ -277,7 +277,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-summarize-meetings" aria-controls="panel-cc-related-summarize-meetings" id="tab-cc-related-summarize-meetings">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-summarize-meetings" aria-labelledby="tab-npx-related-summarize-meetings" data-panel="npx-related-summarize-meetings"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings-npx">npx skills add 2389-research/summarize-meetings</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-summarize-meetings" aria-labelledby="tab-cc-related-summarize-meetings" data-panel="cc-related-summarize-meetings" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">/plugin install 2389-research/summarize-meetings</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-summarize-meetings" aria-labelledby="tab-cc-related-summarize-meetings" data-panel="cc-related-summarize-meetings" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">/plugin install summarize-meetings@2389-research</code></div>
           </div>
             <a href="../summarize-meetings/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="summarize-meetings">Details →</a>
           </div>
@@ -293,7 +293,7 @@
           <p class="plugin-description">A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts</p>
           <div class="plugin-tags"><span class="tag">journal</span><span class="tag">journaling</span><span class="tag">thoughts</span></div>
           <div class="plugin-footer">
-            <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="journal">/plugin install 2389-research/journal</code>
+            <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="journal">/plugin install journal@2389-research</code>
             <a href="../journal/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="journal">Details →</a>
           </div>
         </article>
@@ -365,8 +365,8 @@
   "downloadUrl": "https://github.com/2389-research/ceo-personal-os",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/ceo-personal-os/index.html
+++ b/docs/plugins/ceo-personal-os/index.html
@@ -365,7 +365,7 @@
   "downloadUrl": "https://github.com/2389-research/ceo-personal-os",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/ceo-personal-os/index.md
+++ b/docs/plugins/ceo-personal-os/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/ceo-personal-os
+/plugin install ceo-personal-os@2389-research
 ```
 
 ## README

--- a/docs/plugins/css-development/index.html
+++ b/docs/plugins/css-development/index.html
@@ -369,7 +369,7 @@
   "downloadUrl": "https://github.com/2389-research/css-development",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/css-development/index.html
+++ b/docs/plugins/css-development/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-css-development" aria-controls="panel-cc-css-development" id="tab-cc-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-css-development" aria-labelledby="tab-npx-css-development" data-panel="npx-css-development"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-css-development" aria-labelledby="tab-cc-css-development" data-panel="cc-css-development" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-css-development" aria-labelledby="tab-cc-css-development" data-panel="cc-css-development" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/css-development" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="css-development">
@@ -210,7 +210,7 @@
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="css-development-install">/plugin install 2389-research/css-development</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="css-development-install">/plugin install css-development@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -252,7 +252,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -274,7 +274,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -296,7 +296,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-xtool" aria-controls="panel-cc-related-xtool" id="tab-cc-related-xtool">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-xtool" aria-labelledby="tab-npx-related-xtool" data-panel="npx-related-xtool"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool-npx">npx skills add 2389-research/xtool</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-xtool" aria-labelledby="tab-cc-related-xtool" data-panel="cc-related-xtool" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool">/plugin install 2389-research/xtool</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-xtool" aria-labelledby="tab-cc-related-xtool" data-panel="cc-related-xtool" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool">/plugin install xtool@2389-research</code></div>
           </div>
             <a href="../xtool/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="xtool">Details →</a>
           </div>
@@ -369,8 +369,8 @@
   "downloadUrl": "https://github.com/2389-research/css-development",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/css-development/index.md
+++ b/docs/plugins/css-development/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/css-development
+/plugin install css-development@2389-research
 ```
 
 ## README

--- a/docs/plugins/deliberation/index.html
+++ b/docs/plugins/deliberation/index.html
@@ -384,7 +384,7 @@ Business Strategist, Developer Culture voice. Anyone to add?"
   "downloadUrl": "https://github.com/2389-research/deliberation",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/deliberation/index.html
+++ b/docs/plugins/deliberation/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-deliberation" aria-controls="panel-cc-deliberation" id="tab-cc-deliberation">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-deliberation" aria-labelledby="tab-npx-deliberation" data-panel="npx-deliberation"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation-npx">npx skills add 2389-research/deliberation</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-deliberation" aria-labelledby="tab-cc-deliberation" data-panel="cc-deliberation" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install 2389-research/deliberation</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-deliberation" aria-labelledby="tab-cc-deliberation" data-panel="cc-deliberation" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install deliberation@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/deliberation" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="deliberation">
@@ -225,7 +225,7 @@ Business Strategist, Developer Culture voice. Anyone to add?"
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="deliberation-install">/plugin install 2389-research/deliberation</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="deliberation-install">/plugin install deliberation@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -267,7 +267,7 @@ Business Strategist, Developer Culture voice. Anyone to add?"
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-building-multiagent-systems" aria-controls="panel-cc-related-building-multiagent-systems" id="tab-cc-related-building-multiagent-systems">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-building-multiagent-systems" aria-labelledby="tab-npx-related-building-multiagent-systems" data-panel="npx-related-building-multiagent-systems"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems-npx">npx skills add 2389-research/building-multiagent-systems</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-building-multiagent-systems" aria-labelledby="tab-cc-related-building-multiagent-systems" data-panel="cc-related-building-multiagent-systems" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install 2389-research/building-multiagent-systems</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-building-multiagent-systems" aria-labelledby="tab-cc-related-building-multiagent-systems" data-panel="cc-related-building-multiagent-systems" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install building-multiagent-systems@2389-research</code></div>
           </div>
             <a href="../building-multiagent-systems/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="building-multiagent-systems">Details →</a>
           </div>
@@ -289,7 +289,7 @@ Business Strategist, Developer Culture voice. Anyone to add?"
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-review-squad" aria-controls="panel-cc-related-review-squad" id="tab-cc-related-review-squad">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-review-squad" aria-labelledby="tab-npx-related-review-squad" data-panel="npx-related-review-squad"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad-npx">npx skills add 2389-research/review-squad</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-review-squad" aria-labelledby="tab-cc-related-review-squad" data-panel="cc-related-review-squad" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install 2389-research/review-squad</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-review-squad" aria-labelledby="tab-cc-related-review-squad" data-panel="cc-related-review-squad" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install review-squad@2389-research</code></div>
           </div>
             <a href="../review-squad/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="review-squad">Details →</a>
           </div>
@@ -311,7 +311,7 @@ Business Strategist, Developer Culture voice. Anyone to add?"
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-jam" aria-controls="panel-cc-related-jam" id="tab-cc-related-jam">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-jam" aria-labelledby="tab-npx-related-jam" data-panel="npx-related-jam"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam-npx">npx skills add 2389-research/jam</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-jam" aria-labelledby="tab-cc-related-jam" data-panel="cc-related-jam" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">/plugin install 2389-research/jam</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-jam" aria-labelledby="tab-cc-related-jam" data-panel="cc-related-jam" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">/plugin install jam@2389-research</code></div>
           </div>
             <a href="../jam/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="jam">Details →</a>
           </div>
@@ -384,8 +384,8 @@ Business Strategist, Developer Culture voice. Anyone to add?"
   "downloadUrl": "https://github.com/2389-research/deliberation",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/deliberation/index.md
+++ b/docs/plugins/deliberation/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/deliberation
+/plugin install deliberation@2389-research
 ```
 
 ## README

--- a/docs/plugins/documentation-audit/index.html
+++ b/docs/plugins/documentation-audit/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-documentation-audit" aria-controls="panel-cc-documentation-audit" id="tab-cc-documentation-audit">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-documentation-audit" aria-labelledby="tab-npx-documentation-audit" data-panel="npx-documentation-audit"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="documentation-audit-npx">npx skills add 2389-research/documentation-audit</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-documentation-audit" aria-labelledby="tab-cc-documentation-audit" data-panel="cc-documentation-audit" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="documentation-audit">/plugin install 2389-research/documentation-audit</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-documentation-audit" aria-labelledby="tab-cc-documentation-audit" data-panel="cc-documentation-audit" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="documentation-audit">/plugin install documentation-audit@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/documentation-audit" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="documentation-audit">
@@ -188,7 +188,7 @@
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="documentation-audit-install">/plugin install 2389-research/documentation-audit</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="documentation-audit-install">/plugin install documentation-audit@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -230,7 +230,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -252,7 +252,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -274,7 +274,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -347,8 +347,8 @@
   "downloadUrl": "https://github.com/2389-research/documentation-audit",
   "softwareVersion": "2.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/documentation-audit/index.html
+++ b/docs/plugins/documentation-audit/index.html
@@ -347,7 +347,7 @@
   "downloadUrl": "https://github.com/2389-research/documentation-audit",
   "softwareVersion": "2.0.1",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/documentation-audit/index.md
+++ b/docs/plugins/documentation-audit/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/documentation-audit
+/plugin install documentation-audit@2389-research
 ```
 
 ## README

--- a/docs/plugins/firebase-development/index.html
+++ b/docs/plugins/firebase-development/index.html
@@ -367,7 +367,7 @@ export const users = {
   "downloadUrl": "https://github.com/2389-research/firebase-development",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/firebase-development/index.html
+++ b/docs/plugins/firebase-development/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-firebase-development" aria-controls="panel-cc-firebase-development" id="tab-cc-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-firebase-development" aria-labelledby="tab-npx-firebase-development" data-panel="npx-firebase-development"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-firebase-development" aria-labelledby="tab-cc-firebase-development" data-panel="cc-firebase-development" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-firebase-development" aria-labelledby="tab-cc-firebase-development" data-panel="cc-firebase-development" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/firebase-development" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="firebase-development">
@@ -208,7 +208,7 @@ export const users = {
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="firebase-development-install">/plugin install 2389-research/firebase-development</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="firebase-development-install">/plugin install firebase-development@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -250,7 +250,7 @@ export const users = {
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -272,7 +272,7 @@ export const users = {
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -294,7 +294,7 @@ export const users = {
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-xtool" aria-controls="panel-cc-related-xtool" id="tab-cc-related-xtool">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-xtool" aria-labelledby="tab-npx-related-xtool" data-panel="npx-related-xtool"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool-npx">npx skills add 2389-research/xtool</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-xtool" aria-labelledby="tab-cc-related-xtool" data-panel="cc-related-xtool" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool">/plugin install 2389-research/xtool</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-xtool" aria-labelledby="tab-cc-related-xtool" data-panel="cc-related-xtool" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool">/plugin install xtool@2389-research</code></div>
           </div>
             <a href="../xtool/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="xtool">Details →</a>
           </div>
@@ -367,8 +367,8 @@ export const users = {
   "downloadUrl": "https://github.com/2389-research/firebase-development",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/firebase-development/index.md
+++ b/docs/plugins/firebase-development/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/firebase-development
+/plugin install firebase-development@2389-research
 ```
 
 ## README

--- a/docs/plugins/fresh-eyes-review/index.html
+++ b/docs/plugins/fresh-eyes-review/index.html
@@ -373,7 +373,7 @@
   "downloadUrl": "https://github.com/2389-research/fresh-eyes-review",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/fresh-eyes-review/index.html
+++ b/docs/plugins/fresh-eyes-review/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-fresh-eyes-review" aria-controls="panel-cc-fresh-eyes-review" id="tab-cc-fresh-eyes-review">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-fresh-eyes-review" aria-labelledby="tab-npx-fresh-eyes-review" data-panel="npx-fresh-eyes-review"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="fresh-eyes-review-npx">npx skills add 2389-research/fresh-eyes-review</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-fresh-eyes-review" aria-labelledby="tab-cc-fresh-eyes-review" data-panel="cc-fresh-eyes-review" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="fresh-eyes-review">/plugin install 2389-research/fresh-eyes-review</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-fresh-eyes-review" aria-labelledby="tab-cc-fresh-eyes-review" data-panel="cc-fresh-eyes-review" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="fresh-eyes-review">/plugin install fresh-eyes-review@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/fresh-eyes-review" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="fresh-eyes-review">
@@ -214,7 +214,7 @@
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="fresh-eyes-review-install">/plugin install 2389-research/fresh-eyes-review</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="fresh-eyes-review-install">/plugin install fresh-eyes-review@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -256,7 +256,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -278,7 +278,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -300,7 +300,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -373,8 +373,8 @@
   "downloadUrl": "https://github.com/2389-research/fresh-eyes-review",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/fresh-eyes-review/index.md
+++ b/docs/plugins/fresh-eyes-review/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/fresh-eyes-review
+/plugin install fresh-eyes-review@2389-research
 ```
 
 ## README

--- a/docs/plugins/git-repo-prep/index.html
+++ b/docs/plugins/git-repo-prep/index.html
@@ -369,7 +369,7 @@
   "downloadUrl": "https://github.com/2389-research/git-repo-prep",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/git-repo-prep/index.html
+++ b/docs/plugins/git-repo-prep/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-git-repo-prep" aria-controls="panel-cc-git-repo-prep" id="tab-cc-git-repo-prep">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-git-repo-prep" aria-labelledby="tab-npx-git-repo-prep" data-panel="npx-git-repo-prep"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="git-repo-prep-npx">npx skills add 2389-research/git-repo-prep</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-git-repo-prep" aria-labelledby="tab-cc-git-repo-prep" data-panel="cc-git-repo-prep" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="git-repo-prep">/plugin install 2389-research/git-repo-prep</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-git-repo-prep" aria-labelledby="tab-cc-git-repo-prep" data-panel="cc-git-repo-prep" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="git-repo-prep">/plugin install git-repo-prep@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/git-repo-prep" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="git-repo-prep">
@@ -210,7 +210,7 @@
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="git-repo-prep-install">/plugin install 2389-research/git-repo-prep</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="git-repo-prep-install">/plugin install git-repo-prep@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -252,7 +252,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -274,7 +274,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -296,7 +296,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -369,8 +369,8 @@
   "downloadUrl": "https://github.com/2389-research/git-repo-prep",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/git-repo-prep/index.md
+++ b/docs/plugins/git-repo-prep/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/git-repo-prep
+/plugin install git-repo-prep@2389-research
 ```
 
 ## README

--- a/docs/plugins/jam/index.html
+++ b/docs/plugins/jam/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-jam" aria-controls="panel-cc-jam" id="tab-cc-jam">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-jam" aria-labelledby="tab-npx-jam" data-panel="npx-jam"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam-npx">npx skills add 2389-research/jam</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-jam" aria-labelledby="tab-cc-jam" data-panel="cc-jam" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">/plugin install 2389-research/jam</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-jam" aria-labelledby="tab-cc-jam" data-panel="cc-jam" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">/plugin install jam@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/jam" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="jam">
@@ -250,7 +250,7 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="jam-install">/plugin install 2389-research/jam</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="jam-install">/plugin install jam@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -292,7 +292,7 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-building-multiagent-systems" aria-controls="panel-cc-related-building-multiagent-systems" id="tab-cc-related-building-multiagent-systems">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-building-multiagent-systems" aria-labelledby="tab-npx-related-building-multiagent-systems" data-panel="npx-related-building-multiagent-systems"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems-npx">npx skills add 2389-research/building-multiagent-systems</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-building-multiagent-systems" aria-labelledby="tab-cc-related-building-multiagent-systems" data-panel="cc-related-building-multiagent-systems" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install 2389-research/building-multiagent-systems</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-building-multiagent-systems" aria-labelledby="tab-cc-related-building-multiagent-systems" data-panel="cc-related-building-multiagent-systems" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install building-multiagent-systems@2389-research</code></div>
           </div>
             <a href="../building-multiagent-systems/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="building-multiagent-systems">Details →</a>
           </div>
@@ -314,7 +314,7 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-deliberation" aria-controls="panel-cc-related-deliberation" id="tab-cc-related-deliberation">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-deliberation" aria-labelledby="tab-npx-related-deliberation" data-panel="npx-related-deliberation"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation-npx">npx skills add 2389-research/deliberation</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-deliberation" aria-labelledby="tab-cc-related-deliberation" data-panel="cc-related-deliberation" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install 2389-research/deliberation</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-deliberation" aria-labelledby="tab-cc-related-deliberation" data-panel="cc-related-deliberation" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install deliberation@2389-research</code></div>
           </div>
             <a href="../deliberation/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="deliberation">Details →</a>
           </div>
@@ -336,7 +336,7 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-review-squad" aria-controls="panel-cc-related-review-squad" id="tab-cc-related-review-squad">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-review-squad" aria-labelledby="tab-npx-related-review-squad" data-panel="npx-related-review-squad"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad-npx">npx skills add 2389-research/review-squad</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-review-squad" aria-labelledby="tab-cc-related-review-squad" data-panel="cc-related-review-squad" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install 2389-research/review-squad</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-review-squad" aria-labelledby="tab-cc-related-review-squad" data-panel="cc-related-review-squad" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install review-squad@2389-research</code></div>
           </div>
             <a href="../review-squad/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="review-squad">Details →</a>
           </div>
@@ -409,8 +409,8 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
   "downloadUrl": "https://github.com/2389-research/jam",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/jam/index.html
+++ b/docs/plugins/jam/index.html
@@ -409,7 +409,7 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
   "downloadUrl": "https://github.com/2389-research/jam",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/jam/index.md
+++ b/docs/plugins/jam/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/jam
+/plugin install jam@2389-research
 ```
 
 ## README

--- a/docs/plugins/journal/index.html
+++ b/docs/plugins/journal/index.html
@@ -96,7 +96,7 @@
       <div class="plugin-hero-actions">
         <div class="install-block">
           <span class="install-label">Install</span>
-          <code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="journal">/plugin install 2389-research/journal</code>
+          <code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="journal">/plugin install journal@2389-research</code>
         </div>
         <a href="https://github.com/2389-research/journal-mcp" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="journal">
           View Source
@@ -334,7 +334,7 @@ Vector embeddings provide semantic understanding...
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="journal-install">/plugin install 2389-research/journal</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="journal-install">/plugin install journal@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -375,7 +375,7 @@ Vector embeddings provide semantic understanding...
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-ceo-personal-os" aria-controls="panel-cc-related-ceo-personal-os" id="tab-cc-related-ceo-personal-os">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-ceo-personal-os" aria-labelledby="tab-npx-related-ceo-personal-os" data-panel="npx-related-ceo-personal-os"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os-npx">npx skills add 2389-research/ceo-personal-os</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-ceo-personal-os" aria-labelledby="tab-cc-related-ceo-personal-os" data-panel="cc-related-ceo-personal-os" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">/plugin install 2389-research/ceo-personal-os</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-ceo-personal-os" aria-labelledby="tab-cc-related-ceo-personal-os" data-panel="cc-related-ceo-personal-os" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">/plugin install ceo-personal-os@2389-research</code></div>
           </div>
             <a href="../ceo-personal-os/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="ceo-personal-os">Details →</a>
           </div>
@@ -397,7 +397,7 @@ Vector embeddings provide semantic understanding...
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-worldview-synthesis" aria-controls="panel-cc-related-worldview-synthesis" id="tab-cc-related-worldview-synthesis">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-worldview-synthesis" aria-labelledby="tab-npx-related-worldview-synthesis" data-panel="npx-related-worldview-synthesis"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis-npx">npx skills add 2389-research/worldview-synthesis</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-worldview-synthesis" aria-labelledby="tab-cc-related-worldview-synthesis" data-panel="cc-related-worldview-synthesis" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">/plugin install 2389-research/worldview-synthesis</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-worldview-synthesis" aria-labelledby="tab-cc-related-worldview-synthesis" data-panel="cc-related-worldview-synthesis" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">/plugin install worldview-synthesis@2389-research</code></div>
           </div>
             <a href="../worldview-synthesis/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="worldview-synthesis">Details →</a>
           </div>
@@ -419,7 +419,7 @@ Vector embeddings provide semantic understanding...
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-summarize-meetings" aria-controls="panel-cc-related-summarize-meetings" id="tab-cc-related-summarize-meetings">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-summarize-meetings" aria-labelledby="tab-npx-related-summarize-meetings" data-panel="npx-related-summarize-meetings"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings-npx">npx skills add 2389-research/summarize-meetings</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-summarize-meetings" aria-labelledby="tab-cc-related-summarize-meetings" data-panel="cc-related-summarize-meetings" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">/plugin install 2389-research/summarize-meetings</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-summarize-meetings" aria-labelledby="tab-cc-related-summarize-meetings" data-panel="cc-related-summarize-meetings" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">/plugin install summarize-meetings@2389-research</code></div>
           </div>
             <a href="../summarize-meetings/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="summarize-meetings">Details →</a>
           </div>
@@ -492,8 +492,8 @@ Vector embeddings provide semantic understanding...
   "downloadUrl": "https://github.com/2389-research/journal-mcp",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/journal/index.html
+++ b/docs/plugins/journal/index.html
@@ -492,7 +492,7 @@ Vector embeddings provide semantic understanding...
   "downloadUrl": "https://github.com/2389-research/journal-mcp",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/journal/index.md
+++ b/docs/plugins/journal/index.md
@@ -11,7 +11,7 @@ This is an MCP server — install it in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/journal
+/plugin install journal@2389-research
 ```
 
 ## README

--- a/docs/plugins/landing-page-design/index.html
+++ b/docs/plugins/landing-page-design/index.html
@@ -388,7 +388,7 @@ Full animation system for entrances, continuous effects, interactions, and decor
   "downloadUrl": "https://github.com/2389-research/landing-page-design",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/landing-page-design/index.html
+++ b/docs/plugins/landing-page-design/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-landing-page-design" aria-controls="panel-cc-landing-page-design" id="tab-cc-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-landing-page-design" aria-labelledby="tab-npx-landing-page-design" data-panel="npx-landing-page-design"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-landing-page-design" aria-labelledby="tab-cc-landing-page-design" data-panel="cc-landing-page-design" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-landing-page-design" aria-labelledby="tab-cc-landing-page-design" data-panel="cc-landing-page-design" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/landing-page-design" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="landing-page-design">
@@ -229,7 +229,7 @@ Full animation system for entrances, continuous effects, interactions, and decor
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="landing-page-design-install">/plugin install 2389-research/landing-page-design</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="landing-page-design-install">/plugin install landing-page-design@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -271,7 +271,7 @@ Full animation system for entrances, continuous effects, interactions, and decor
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -293,7 +293,7 @@ Full animation system for entrances, continuous effects, interactions, and decor
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -315,7 +315,7 @@ Full animation system for entrances, continuous effects, interactions, and decor
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-xtool" aria-controls="panel-cc-related-xtool" id="tab-cc-related-xtool">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-xtool" aria-labelledby="tab-npx-related-xtool" data-panel="npx-related-xtool"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool-npx">npx skills add 2389-research/xtool</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-xtool" aria-labelledby="tab-cc-related-xtool" data-panel="cc-related-xtool" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool">/plugin install 2389-research/xtool</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-xtool" aria-labelledby="tab-cc-related-xtool" data-panel="cc-related-xtool" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool">/plugin install xtool@2389-research</code></div>
           </div>
             <a href="../xtool/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="xtool">Details →</a>
           </div>
@@ -388,8 +388,8 @@ Full animation system for entrances, continuous effects, interactions, and decor
   "downloadUrl": "https://github.com/2389-research/landing-page-design",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/landing-page-design/index.md
+++ b/docs/plugins/landing-page-design/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/landing-page-design
+/plugin install landing-page-design@2389-research
 ```
 
 ## README

--- a/docs/plugins/prbuddy/index.html
+++ b/docs/plugins/prbuddy/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-prbuddy" aria-controls="panel-cc-prbuddy" id="tab-cc-prbuddy">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-prbuddy" aria-labelledby="tab-npx-prbuddy" data-panel="npx-prbuddy"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="prbuddy-npx">npx skills add 2389-research/prbuddy</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-prbuddy" aria-labelledby="tab-cc-prbuddy" data-panel="cc-prbuddy" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="prbuddy">/plugin install 2389-research/prbuddy</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-prbuddy" aria-labelledby="tab-cc-prbuddy" data-panel="cc-prbuddy" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="prbuddy">/plugin install prbuddy@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/prbuddy" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="prbuddy">
@@ -188,7 +188,7 @@
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="prbuddy-install">/plugin install 2389-research/prbuddy</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="prbuddy-install">/plugin install prbuddy@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -230,7 +230,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -252,7 +252,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -274,7 +274,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -347,8 +347,8 @@
   "downloadUrl": "https://github.com/2389-research/prbuddy",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/prbuddy/index.html
+++ b/docs/plugins/prbuddy/index.html
@@ -347,7 +347,7 @@
   "downloadUrl": "https://github.com/2389-research/prbuddy",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/prbuddy/index.md
+++ b/docs/plugins/prbuddy/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/prbuddy
+/plugin install prbuddy@2389-research
 ```
 
 ## README

--- a/docs/plugins/remote-system-maintenance/index.html
+++ b/docs/plugins/remote-system-maintenance/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-remote-system-maintenance" aria-controls="panel-cc-remote-system-maintenance" id="tab-cc-remote-system-maintenance">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-remote-system-maintenance" aria-labelledby="tab-npx-remote-system-maintenance" data-panel="npx-remote-system-maintenance"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance-npx">npx skills add 2389-research/remote-system-maintenance</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-remote-system-maintenance" aria-labelledby="tab-cc-remote-system-maintenance" data-panel="cc-remote-system-maintenance" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance">/plugin install 2389-research/remote-system-maintenance</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-remote-system-maintenance" aria-labelledby="tab-cc-remote-system-maintenance" data-panel="cc-remote-system-maintenance" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance">/plugin install remote-system-maintenance@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/remote-system-maintenance" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="remote-system-maintenance">
@@ -257,7 +257,7 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="remote-system-maintenance-install">/plugin install 2389-research/remote-system-maintenance</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="remote-system-maintenance-install">/plugin install remote-system-maintenance@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -299,7 +299,7 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-terminal-title" aria-controls="panel-cc-related-terminal-title" id="tab-cc-related-terminal-title">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-terminal-title" aria-labelledby="tab-npx-related-terminal-title" data-panel="npx-related-terminal-title"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title-npx">npx skills add 2389-research/terminal-title</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-terminal-title" aria-labelledby="tab-cc-related-terminal-title" data-panel="cc-related-terminal-title" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title">/plugin install 2389-research/terminal-title</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-terminal-title" aria-labelledby="tab-cc-related-terminal-title" data-panel="cc-related-terminal-title" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title">/plugin install terminal-title@2389-research</code></div>
           </div>
             <a href="../terminal-title/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="terminal-title">Details →</a>
           </div>
@@ -321,7 +321,7 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-binary-re" aria-controls="panel-cc-related-binary-re" id="tab-cc-related-binary-re">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-binary-re" aria-labelledby="tab-npx-related-binary-re" data-panel="npx-related-binary-re"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re-npx">npx skills add 2389-research/binary-re</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-binary-re" aria-labelledby="tab-cc-related-binary-re" data-panel="cc-related-binary-re" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re">/plugin install 2389-research/binary-re</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-binary-re" aria-labelledby="tab-cc-related-binary-re" data-panel="cc-related-binary-re" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re">/plugin install binary-re@2389-research</code></div>
           </div>
             <a href="../binary-re/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="binary-re">Details →</a>
           </div>
@@ -394,8 +394,8 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
   "downloadUrl": "https://github.com/2389-research/remote-system-maintenance",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/remote-system-maintenance/index.html
+++ b/docs/plugins/remote-system-maintenance/index.html
@@ -394,7 +394,7 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
   "downloadUrl": "https://github.com/2389-research/remote-system-maintenance",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/remote-system-maintenance/index.md
+++ b/docs/plugins/remote-system-maintenance/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/remote-system-maintenance
+/plugin install remote-system-maintenance@2389-research
 ```
 
 ## README

--- a/docs/plugins/review-squad/index.html
+++ b/docs/plugins/review-squad/index.html
@@ -393,7 +393,7 @@ things professional reviewers skip because they're too polite.
   "downloadUrl": "https://github.com/2389-research/review-squad",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/review-squad/index.html
+++ b/docs/plugins/review-squad/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-review-squad" aria-controls="panel-cc-review-squad" id="tab-cc-review-squad">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-review-squad" aria-labelledby="tab-npx-review-squad" data-panel="npx-review-squad"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad-npx">npx skills add 2389-research/review-squad</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-review-squad" aria-labelledby="tab-cc-review-squad" data-panel="cc-review-squad" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install 2389-research/review-squad</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-review-squad" aria-labelledby="tab-cc-review-squad" data-panel="cc-review-squad" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install review-squad@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/review-squad" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="review-squad">
@@ -234,7 +234,7 @@ things professional reviewers skip because they're too polite.
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="review-squad-install">/plugin install 2389-research/review-squad</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="review-squad-install">/plugin install review-squad@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -276,7 +276,7 @@ things professional reviewers skip because they're too polite.
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-building-multiagent-systems" aria-controls="panel-cc-related-building-multiagent-systems" id="tab-cc-related-building-multiagent-systems">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-building-multiagent-systems" aria-labelledby="tab-npx-related-building-multiagent-systems" data-panel="npx-related-building-multiagent-systems"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems-npx">npx skills add 2389-research/building-multiagent-systems</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-building-multiagent-systems" aria-labelledby="tab-cc-related-building-multiagent-systems" data-panel="cc-related-building-multiagent-systems" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install 2389-research/building-multiagent-systems</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-building-multiagent-systems" aria-labelledby="tab-cc-related-building-multiagent-systems" data-panel="cc-related-building-multiagent-systems" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install building-multiagent-systems@2389-research</code></div>
           </div>
             <a href="../building-multiagent-systems/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="building-multiagent-systems">Details →</a>
           </div>
@@ -298,7 +298,7 @@ things professional reviewers skip because they're too polite.
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-deliberation" aria-controls="panel-cc-related-deliberation" id="tab-cc-related-deliberation">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-deliberation" aria-labelledby="tab-npx-related-deliberation" data-panel="npx-related-deliberation"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation-npx">npx skills add 2389-research/deliberation</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-deliberation" aria-labelledby="tab-cc-related-deliberation" data-panel="cc-related-deliberation" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install 2389-research/deliberation</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-deliberation" aria-labelledby="tab-cc-related-deliberation" data-panel="cc-related-deliberation" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install deliberation@2389-research</code></div>
           </div>
             <a href="../deliberation/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="deliberation">Details →</a>
           </div>
@@ -320,7 +320,7 @@ things professional reviewers skip because they're too polite.
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-jam" aria-controls="panel-cc-related-jam" id="tab-cc-related-jam">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-jam" aria-labelledby="tab-npx-related-jam" data-panel="npx-related-jam"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam-npx">npx skills add 2389-research/jam</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-jam" aria-labelledby="tab-cc-related-jam" data-panel="cc-related-jam" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">/plugin install 2389-research/jam</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-jam" aria-labelledby="tab-cc-related-jam" data-panel="cc-related-jam" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">/plugin install jam@2389-research</code></div>
           </div>
             <a href="../jam/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="jam">Details →</a>
           </div>
@@ -393,8 +393,8 @@ things professional reviewers skip because they're too polite.
   "downloadUrl": "https://github.com/2389-research/review-squad",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/review-squad/index.md
+++ b/docs/plugins/review-squad/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/review-squad
+/plugin install review-squad@2389-research
 ```
 
 ## README

--- a/docs/plugins/scenario-testing/index.html
+++ b/docs/plugins/scenario-testing/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-scenario-testing" aria-controls="panel-cc-scenario-testing" id="tab-cc-scenario-testing">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-scenario-testing" aria-labelledby="tab-npx-scenario-testing" data-panel="npx-scenario-testing"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="scenario-testing-npx">npx skills add 2389-research/scenario-testing</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-scenario-testing" aria-labelledby="tab-cc-scenario-testing" data-panel="cc-scenario-testing" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="scenario-testing">/plugin install 2389-research/scenario-testing</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-scenario-testing" aria-labelledby="tab-cc-scenario-testing" data-panel="cc-scenario-testing" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="scenario-testing">/plugin install scenario-testing@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/scenario-testing" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="scenario-testing">
@@ -258,7 +258,7 @@ def test_user_registration_scenario():
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="scenario-testing-install">/plugin install 2389-research/scenario-testing</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="scenario-testing-install">/plugin install scenario-testing@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -300,7 +300,7 @@ def test_user_registration_scenario():
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -322,7 +322,7 @@ def test_user_registration_scenario():
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -344,7 +344,7 @@ def test_user_registration_scenario():
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -417,8 +417,8 @@ def test_user_registration_scenario():
   "downloadUrl": "https://github.com/2389-research/scenario-testing",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/scenario-testing/index.html
+++ b/docs/plugins/scenario-testing/index.html
@@ -417,7 +417,7 @@ def test_user_registration_scenario():
   "downloadUrl": "https://github.com/2389-research/scenario-testing",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/scenario-testing/index.md
+++ b/docs/plugins/scenario-testing/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/scenario-testing
+/plugin install scenario-testing@2389-research
 ```
 
 ## README

--- a/docs/plugins/simmer/index.html
+++ b/docs/plugins/simmer/index.html
@@ -451,7 +451,7 @@ docs/simmer/                   # Tracking files (separate from workspace)
   "downloadUrl": "https://github.com/2389-research/simmer",
   "softwareVersion": "3.0.1",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/simmer/index.html
+++ b/docs/plugins/simmer/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-simmer" aria-controls="panel-cc-simmer" id="tab-cc-simmer">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-simmer" aria-labelledby="tab-npx-simmer" data-panel="npx-simmer"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="simmer-npx">npx skills add 2389-research/simmer</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-simmer" aria-labelledby="tab-cc-simmer" data-panel="cc-simmer" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="simmer">/plugin install 2389-research/simmer</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-simmer" aria-labelledby="tab-cc-simmer" data-panel="cc-simmer" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="simmer">/plugin install simmer@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/simmer" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="simmer">
@@ -292,7 +292,7 @@ docs/simmer/                   # Tracking files (separate from workspace)
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="simmer-install">/plugin install 2389-research/simmer</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="simmer-install">/plugin install simmer@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -334,7 +334,7 @@ docs/simmer/                   # Tracking files (separate from workspace)
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -356,7 +356,7 @@ docs/simmer/                   # Tracking files (separate from workspace)
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -378,7 +378,7 @@ docs/simmer/                   # Tracking files (separate from workspace)
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -451,8 +451,8 @@ docs/simmer/                   # Tracking files (separate from workspace)
   "downloadUrl": "https://github.com/2389-research/simmer",
   "softwareVersion": "3.0.1",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/simmer/index.md
+++ b/docs/plugins/simmer/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/simmer
+/plugin install simmer@2389-research
 ```
 
 ## README

--- a/docs/plugins/slack-mcp/index.html
+++ b/docs/plugins/slack-mcp/index.html
@@ -406,7 +406,7 @@ npm start
   "downloadUrl": "https://github.com/2389-research/slack-mcp",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/slack-mcp/index.html
+++ b/docs/plugins/slack-mcp/index.html
@@ -96,7 +96,7 @@
       <div class="plugin-hero-actions">
         <div class="install-block">
           <span class="install-label">Install</span>
-          <code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="slack-mcp">/plugin install 2389-research/slack-mcp</code>
+          <code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="slack-mcp">/plugin install slack-mcp@2389-research</code>
         </div>
         <a href="https://github.com/2389-research/slack-mcp" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="slack-mcp">
           View Source
@@ -248,7 +248,7 @@ npm start
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="slack-mcp-install">/plugin install 2389-research/slack-mcp</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="slack-mcp-install">/plugin install slack-mcp@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -289,7 +289,7 @@ npm start
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -311,7 +311,7 @@ npm start
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -333,7 +333,7 @@ npm start
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -406,8 +406,8 @@ npm start
   "downloadUrl": "https://github.com/2389-research/slack-mcp",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/slack-mcp/index.md
+++ b/docs/plugins/slack-mcp/index.md
@@ -11,7 +11,7 @@ This is an MCP server — install it in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/slack-mcp
+/plugin install slack-mcp@2389-research
 ```
 
 ## README

--- a/docs/plugins/socialmedia/index.html
+++ b/docs/plugins/socialmedia/index.html
@@ -391,7 +391,7 @@ docker-compose up -d
   "downloadUrl": "https://github.com/2389-research/mcp-socialmedia",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/socialmedia/index.html
+++ b/docs/plugins/socialmedia/index.html
@@ -96,7 +96,7 @@
       <div class="plugin-hero-actions">
         <div class="install-block">
           <span class="install-label">Install</span>
-          <code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="socialmedia">/plugin install 2389-research/socialmedia</code>
+          <code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="socialmedia">/plugin install socialmedia@2389-research</code>
         </div>
         <a href="https://github.com/2389-research/mcp-socialmedia" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="socialmedia">
           View Source
@@ -233,7 +233,7 @@ docker-compose up -d
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="socialmedia-install">/plugin install 2389-research/socialmedia</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="socialmedia-install">/plugin install socialmedia@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -274,7 +274,7 @@ docker-compose up -d
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-building-multiagent-systems" aria-controls="panel-cc-related-building-multiagent-systems" id="tab-cc-related-building-multiagent-systems">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-building-multiagent-systems" aria-labelledby="tab-npx-related-building-multiagent-systems" data-panel="npx-related-building-multiagent-systems"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems-npx">npx skills add 2389-research/building-multiagent-systems</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-building-multiagent-systems" aria-labelledby="tab-cc-related-building-multiagent-systems" data-panel="cc-related-building-multiagent-systems" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install 2389-research/building-multiagent-systems</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-building-multiagent-systems" aria-labelledby="tab-cc-related-building-multiagent-systems" data-panel="cc-related-building-multiagent-systems" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">/plugin install building-multiagent-systems@2389-research</code></div>
           </div>
             <a href="../building-multiagent-systems/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="building-multiagent-systems">Details →</a>
           </div>
@@ -296,7 +296,7 @@ docker-compose up -d
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-deliberation" aria-controls="panel-cc-related-deliberation" id="tab-cc-related-deliberation">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-deliberation" aria-labelledby="tab-npx-related-deliberation" data-panel="npx-related-deliberation"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation-npx">npx skills add 2389-research/deliberation</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-deliberation" aria-labelledby="tab-cc-related-deliberation" data-panel="cc-related-deliberation" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install 2389-research/deliberation</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-deliberation" aria-labelledby="tab-cc-related-deliberation" data-panel="cc-related-deliberation" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">/plugin install deliberation@2389-research</code></div>
           </div>
             <a href="../deliberation/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="deliberation">Details →</a>
           </div>
@@ -318,7 +318,7 @@ docker-compose up -d
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-review-squad" aria-controls="panel-cc-related-review-squad" id="tab-cc-related-review-squad">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-review-squad" aria-labelledby="tab-npx-related-review-squad" data-panel="npx-related-review-squad"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad-npx">npx skills add 2389-research/review-squad</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-review-squad" aria-labelledby="tab-cc-related-review-squad" data-panel="cc-related-review-squad" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install 2389-research/review-squad</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-review-squad" aria-labelledby="tab-cc-related-review-squad" data-panel="cc-related-review-squad" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">/plugin install review-squad@2389-research</code></div>
           </div>
             <a href="../review-squad/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="review-squad">Details →</a>
           </div>
@@ -391,8 +391,8 @@ docker-compose up -d
   "downloadUrl": "https://github.com/2389-research/mcp-socialmedia",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/socialmedia/index.md
+++ b/docs/plugins/socialmedia/index.md
@@ -11,7 +11,7 @@ This is an MCP server — install it in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/socialmedia
+/plugin install socialmedia@2389-research
 ```
 
 ## README

--- a/docs/plugins/speed-run/index.html
+++ b/docs/plugins/speed-run/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-speed-run" aria-controls="panel-cc-speed-run" id="tab-cc-speed-run">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-speed-run" aria-labelledby="tab-npx-speed-run" data-panel="npx-speed-run"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="speed-run-npx">npx skills add 2389-research/speed-run</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-speed-run" aria-labelledby="tab-cc-speed-run" data-panel="cc-speed-run" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="speed-run">/plugin install 2389-research/speed-run</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-speed-run" aria-labelledby="tab-cc-speed-run" data-panel="cc-speed-run" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="speed-run">/plugin install speed-run@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/speed-run" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="speed-run">
@@ -270,7 +270,7 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="speed-run-install">/plugin install 2389-research/speed-run</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="speed-run-install">/plugin install speed-run@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -312,7 +312,7 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -334,7 +334,7 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -356,7 +356,7 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -429,8 +429,8 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
   "downloadUrl": "https://github.com/2389-research/speed-run",
   "softwareVersion": "1.1.1",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/speed-run/index.html
+++ b/docs/plugins/speed-run/index.html
@@ -429,7 +429,7 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
   "downloadUrl": "https://github.com/2389-research/speed-run",
   "softwareVersion": "1.1.1",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/speed-run/index.md
+++ b/docs/plugins/speed-run/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/speed-run
+/plugin install speed-run@2389-research
 ```
 
 ## README

--- a/docs/plugins/summarize-meetings/index.html
+++ b/docs/plugins/summarize-meetings/index.html
@@ -354,7 +354,7 @@
   "downloadUrl": "https://github.com/2389-research/summarize-meetings",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/summarize-meetings/index.html
+++ b/docs/plugins/summarize-meetings/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-summarize-meetings" aria-controls="panel-cc-summarize-meetings" id="tab-cc-summarize-meetings">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-summarize-meetings" aria-labelledby="tab-npx-summarize-meetings" data-panel="npx-summarize-meetings"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings-npx">npx skills add 2389-research/summarize-meetings</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-summarize-meetings" aria-labelledby="tab-cc-summarize-meetings" data-panel="cc-summarize-meetings" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">/plugin install 2389-research/summarize-meetings</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-summarize-meetings" aria-labelledby="tab-cc-summarize-meetings" data-panel="cc-summarize-meetings" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">/plugin install summarize-meetings@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/summarize-meetings" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="summarize-meetings">
@@ -202,7 +202,7 @@
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="summarize-meetings-install">/plugin install 2389-research/summarize-meetings</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="summarize-meetings-install">/plugin install summarize-meetings@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -244,7 +244,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-ceo-personal-os" aria-controls="panel-cc-related-ceo-personal-os" id="tab-cc-related-ceo-personal-os">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-ceo-personal-os" aria-labelledby="tab-npx-related-ceo-personal-os" data-panel="npx-related-ceo-personal-os"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os-npx">npx skills add 2389-research/ceo-personal-os</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-ceo-personal-os" aria-labelledby="tab-cc-related-ceo-personal-os" data-panel="cc-related-ceo-personal-os" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">/plugin install 2389-research/ceo-personal-os</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-ceo-personal-os" aria-labelledby="tab-cc-related-ceo-personal-os" data-panel="cc-related-ceo-personal-os" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">/plugin install ceo-personal-os@2389-research</code></div>
           </div>
             <a href="../ceo-personal-os/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="ceo-personal-os">Details →</a>
           </div>
@@ -266,7 +266,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-worldview-synthesis" aria-controls="panel-cc-related-worldview-synthesis" id="tab-cc-related-worldview-synthesis">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-worldview-synthesis" aria-labelledby="tab-npx-related-worldview-synthesis" data-panel="npx-related-worldview-synthesis"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis-npx">npx skills add 2389-research/worldview-synthesis</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-worldview-synthesis" aria-labelledby="tab-cc-related-worldview-synthesis" data-panel="cc-related-worldview-synthesis" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">/plugin install 2389-research/worldview-synthesis</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-worldview-synthesis" aria-labelledby="tab-cc-related-worldview-synthesis" data-panel="cc-related-worldview-synthesis" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">/plugin install worldview-synthesis@2389-research</code></div>
           </div>
             <a href="../worldview-synthesis/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="worldview-synthesis">Details →</a>
           </div>
@@ -282,7 +282,7 @@
           <p class="plugin-description">A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts</p>
           <div class="plugin-tags"><span class="tag">journal</span><span class="tag">journaling</span><span class="tag">thoughts</span></div>
           <div class="plugin-footer">
-            <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="journal">/plugin install 2389-research/journal</code>
+            <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="journal">/plugin install journal@2389-research</code>
             <a href="../journal/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="journal">Details →</a>
           </div>
         </article>
@@ -354,8 +354,8 @@
   "downloadUrl": "https://github.com/2389-research/summarize-meetings",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/summarize-meetings/index.md
+++ b/docs/plugins/summarize-meetings/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/summarize-meetings
+/plugin install summarize-meetings@2389-research
 ```
 
 ## README

--- a/docs/plugins/terminal-title/index.html
+++ b/docs/plugins/terminal-title/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-terminal-title" aria-controls="panel-cc-terminal-title" id="tab-cc-terminal-title">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-terminal-title" aria-labelledby="tab-npx-terminal-title" data-panel="npx-terminal-title"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title-npx">npx skills add 2389-research/terminal-title</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-terminal-title" aria-labelledby="tab-cc-terminal-title" data-panel="cc-terminal-title" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title">/plugin install 2389-research/terminal-title</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-terminal-title" aria-labelledby="tab-cc-terminal-title" data-panel="cc-terminal-title" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title">/plugin install terminal-title@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/terminal-title" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="terminal-title">
@@ -231,7 +231,7 @@ export TERMINAL_TITLE_EMOJI=💼
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="terminal-title-install">/plugin install 2389-research/terminal-title</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="terminal-title-install">/plugin install terminal-title@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -273,7 +273,7 @@ export TERMINAL_TITLE_EMOJI=💼
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-remote-system-maintenance" aria-controls="panel-cc-related-remote-system-maintenance" id="tab-cc-related-remote-system-maintenance">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-remote-system-maintenance" aria-labelledby="tab-npx-related-remote-system-maintenance" data-panel="npx-related-remote-system-maintenance"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance-npx">npx skills add 2389-research/remote-system-maintenance</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-remote-system-maintenance" aria-labelledby="tab-cc-related-remote-system-maintenance" data-panel="cc-related-remote-system-maintenance" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance">/plugin install 2389-research/remote-system-maintenance</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-remote-system-maintenance" aria-labelledby="tab-cc-related-remote-system-maintenance" data-panel="cc-related-remote-system-maintenance" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="remote-system-maintenance">/plugin install remote-system-maintenance@2389-research</code></div>
           </div>
             <a href="../remote-system-maintenance/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="remote-system-maintenance">Details →</a>
           </div>
@@ -295,7 +295,7 @@ export TERMINAL_TITLE_EMOJI=💼
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-binary-re" aria-controls="panel-cc-related-binary-re" id="tab-cc-related-binary-re">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-binary-re" aria-labelledby="tab-npx-related-binary-re" data-panel="npx-related-binary-re"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re-npx">npx skills add 2389-research/binary-re</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-binary-re" aria-labelledby="tab-cc-related-binary-re" data-panel="cc-related-binary-re" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re">/plugin install 2389-research/binary-re</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-binary-re" aria-labelledby="tab-cc-related-binary-re" data-panel="cc-related-binary-re" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re">/plugin install binary-re@2389-research</code></div>
           </div>
             <a href="../binary-re/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="binary-re">Details →</a>
           </div>
@@ -368,8 +368,8 @@ export TERMINAL_TITLE_EMOJI=💼
   "downloadUrl": "https://github.com/2389-research/terminal-title",
   "softwareVersion": "1.1.2",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/terminal-title/index.html
+++ b/docs/plugins/terminal-title/index.html
@@ -368,7 +368,7 @@ export TERMINAL_TITLE_EMOJI=💼
   "downloadUrl": "https://github.com/2389-research/terminal-title",
   "softwareVersion": "1.1.2",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/terminal-title/index.md
+++ b/docs/plugins/terminal-title/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/terminal-title
+/plugin install terminal-title@2389-research
 ```
 
 ## README

--- a/docs/plugins/test-kitchen/index.html
+++ b/docs/plugins/test-kitchen/index.html
@@ -439,7 +439,7 @@ Which approach?
   "downloadUrl": "https://github.com/2389-research/test-kitchen",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/test-kitchen/index.html
+++ b/docs/plugins/test-kitchen/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-test-kitchen" aria-controls="panel-cc-test-kitchen" id="tab-cc-test-kitchen">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-test-kitchen" aria-labelledby="tab-npx-test-kitchen" data-panel="npx-test-kitchen"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="test-kitchen-npx">npx skills add 2389-research/test-kitchen</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-test-kitchen" aria-labelledby="tab-cc-test-kitchen" data-panel="cc-test-kitchen" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="test-kitchen">/plugin install 2389-research/test-kitchen</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-test-kitchen" aria-labelledby="tab-cc-test-kitchen" data-panel="cc-test-kitchen" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="test-kitchen">/plugin install test-kitchen@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/test-kitchen" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="test-kitchen">
@@ -280,7 +280,7 @@ Which approach?
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="test-kitchen-install">/plugin install 2389-research/test-kitchen</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="test-kitchen-install">/plugin install test-kitchen@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -322,7 +322,7 @@ Which approach?
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -344,7 +344,7 @@ Which approach?
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -366,7 +366,7 @@ Which approach?
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -439,8 +439,8 @@ Which approach?
   "downloadUrl": "https://github.com/2389-research/test-kitchen",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/test-kitchen/index.md
+++ b/docs/plugins/test-kitchen/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/test-kitchen
+/plugin install test-kitchen@2389-research
 ```
 
 ## README

--- a/docs/plugins/worldview-synthesis/index.html
+++ b/docs/plugins/worldview-synthesis/index.html
@@ -376,7 +376,7 @@ Find the cracks. Leave no trace.
   "downloadUrl": "https://github.com/2389-research/worldview-synthesis",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/worldview-synthesis/index.html
+++ b/docs/plugins/worldview-synthesis/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-worldview-synthesis" aria-controls="panel-cc-worldview-synthesis" id="tab-cc-worldview-synthesis">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-worldview-synthesis" aria-labelledby="tab-npx-worldview-synthesis" data-panel="npx-worldview-synthesis"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis-npx">npx skills add 2389-research/worldview-synthesis</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-worldview-synthesis" aria-labelledby="tab-cc-worldview-synthesis" data-panel="cc-worldview-synthesis" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">/plugin install 2389-research/worldview-synthesis</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-worldview-synthesis" aria-labelledby="tab-cc-worldview-synthesis" data-panel="cc-worldview-synthesis" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">/plugin install worldview-synthesis@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/worldview-synthesis" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="worldview-synthesis">
@@ -224,7 +224,7 @@ Find the cracks. Leave no trace.
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="worldview-synthesis-install">/plugin install 2389-research/worldview-synthesis</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="worldview-synthesis-install">/plugin install worldview-synthesis@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -266,7 +266,7 @@ Find the cracks. Leave no trace.
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-ceo-personal-os" aria-controls="panel-cc-related-ceo-personal-os" id="tab-cc-related-ceo-personal-os">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-ceo-personal-os" aria-labelledby="tab-npx-related-ceo-personal-os" data-panel="npx-related-ceo-personal-os"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os-npx">npx skills add 2389-research/ceo-personal-os</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-ceo-personal-os" aria-labelledby="tab-cc-related-ceo-personal-os" data-panel="cc-related-ceo-personal-os" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">/plugin install 2389-research/ceo-personal-os</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-ceo-personal-os" aria-labelledby="tab-cc-related-ceo-personal-os" data-panel="cc-related-ceo-personal-os" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">/plugin install ceo-personal-os@2389-research</code></div>
           </div>
             <a href="../ceo-personal-os/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="ceo-personal-os">Details →</a>
           </div>
@@ -288,7 +288,7 @@ Find the cracks. Leave no trace.
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-summarize-meetings" aria-controls="panel-cc-related-summarize-meetings" id="tab-cc-related-summarize-meetings">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-summarize-meetings" aria-labelledby="tab-npx-related-summarize-meetings" data-panel="npx-related-summarize-meetings"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings-npx">npx skills add 2389-research/summarize-meetings</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-summarize-meetings" aria-labelledby="tab-cc-related-summarize-meetings" data-panel="cc-related-summarize-meetings" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">/plugin install 2389-research/summarize-meetings</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-summarize-meetings" aria-labelledby="tab-cc-related-summarize-meetings" data-panel="cc-related-summarize-meetings" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">/plugin install summarize-meetings@2389-research</code></div>
           </div>
             <a href="../summarize-meetings/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="summarize-meetings">Details →</a>
           </div>
@@ -304,7 +304,7 @@ Find the cracks. Leave no trace.
           <p class="plugin-description">A lightweight MCP server that provides Claude with a private journaling capability to process feelings and thoughts</p>
           <div class="plugin-tags"><span class="tag">journal</span><span class="tag">journaling</span><span class="tag">thoughts</span></div>
           <div class="plugin-footer">
-            <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="journal">/plugin install 2389-research/journal</code>
+            <code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="journal">/plugin install journal@2389-research</code>
             <a href="../journal/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="journal">Details →</a>
           </div>
         </article>
@@ -376,8 +376,8 @@ Find the cracks. Leave no trace.
   "downloadUrl": "https://github.com/2389-research/worldview-synthesis",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/worldview-synthesis/index.md
+++ b/docs/plugins/worldview-synthesis/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/worldview-synthesis
+/plugin install worldview-synthesis@2389-research
 ```
 
 ## README

--- a/docs/plugins/xtool/index.html
+++ b/docs/plugins/xtool/index.html
@@ -102,7 +102,7 @@
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-xtool" aria-controls="panel-cc-xtool" id="tab-cc-xtool">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-xtool" aria-labelledby="tab-npx-xtool" data-panel="npx-xtool"><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool-npx">npx skills add 2389-research/xtool</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-xtool" aria-labelledby="tab-cc-xtool" data-panel="cc-xtool" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool">/plugin install 2389-research/xtool</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-xtool" aria-labelledby="tab-cc-xtool" data-panel="cc-xtool" hidden><code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="xtool">/plugin install xtool@2389-research</code></div>
           </div>
         </div>
         <a href="https://github.com/2389-research/xtool" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="xtool">
@@ -211,7 +211,7 @@ xtool dev
             <span class="step-number">2</span>
             <div class="step-content">
               <span class="step-label">Install this plugin</span>
-              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="xtool-install">/plugin install 2389-research/xtool</code>
+              <code data-tinylytics-event="install.copy-command" data-tinylytics-event-value="xtool-install">/plugin install xtool@2389-research</code>
             </div>
           </div>
           <div class="step">
@@ -253,7 +253,7 @@ xtool dev
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-css-development" aria-controls="panel-cc-related-css-development" id="tab-cc-related-css-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-css-development" aria-labelledby="tab-npx-related-css-development" data-panel="npx-related-css-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development-npx">npx skills add 2389-research/css-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install 2389-research/css-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-css-development" aria-labelledby="tab-cc-related-css-development" data-panel="cc-related-css-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="css-development">/plugin install css-development@2389-research</code></div>
           </div>
             <a href="../css-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="css-development">Details →</a>
           </div>
@@ -275,7 +275,7 @@ xtool dev
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-firebase-development" aria-controls="panel-cc-related-firebase-development" id="tab-cc-related-firebase-development">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-firebase-development" aria-labelledby="tab-npx-related-firebase-development" data-panel="npx-related-firebase-development"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development-npx">npx skills add 2389-research/firebase-development</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install 2389-research/firebase-development</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-firebase-development" aria-labelledby="tab-cc-related-firebase-development" data-panel="cc-related-firebase-development" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="firebase-development">/plugin install firebase-development@2389-research</code></div>
           </div>
             <a href="../firebase-development/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="firebase-development">Details →</a>
           </div>
@@ -297,7 +297,7 @@ xtool dev
               <button type="button" class="install-tab" role="tab" aria-selected="false" data-tab="cc-related-landing-page-design" aria-controls="panel-cc-related-landing-page-design" id="tab-cc-related-landing-page-design">Claude Code</button>
             </div>
             <div class="install-tab-panel" role="tabpanel" id="panel-npx-related-landing-page-design" aria-labelledby="tab-npx-related-landing-page-design" data-panel="npx-related-landing-page-design"><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design-npx">npx skills add 2389-research/landing-page-design</code></div>
-            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install 2389-research/landing-page-design</code></div>
+            <div class="install-tab-panel" role="tabpanel" id="panel-cc-related-landing-page-design" aria-labelledby="tab-cc-related-landing-page-design" data-panel="cc-related-landing-page-design" hidden><code class="plugin-install" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">/plugin install landing-page-design@2389-research</code></div>
           </div>
             <a href="../landing-page-design/" class="plugin-source" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="landing-page-design">Details →</a>
           </div>
@@ -370,8 +370,8 @@ xtool dev
   "downloadUrl": "https://github.com/2389-research/xtool",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-28",
-  "dateModified": "2026-05-28"
+  "datePublished": "2026-05-21",
+  "dateModified": "2026-06-01"
 }
   </script>
 

--- a/docs/plugins/xtool/index.html
+++ b/docs/plugins/xtool/index.html
@@ -370,7 +370,7 @@ xtool dev
   "downloadUrl": "https://github.com/2389-research/xtool",
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
-  "datePublished": "2026-05-21",
+  "datePublished": "2026-06-01",
   "dateModified": "2026-06-01"
 }
   </script>

--- a/docs/plugins/xtool/index.md
+++ b/docs/plugins/xtool/index.md
@@ -17,7 +17,7 @@ Or natively in Claude Code:
 
 ```
 /plugin marketplace add 2389-research/claude-plugins
-/plugin install 2389-research/xtool
+/plugin install xtool@2389-research
 ```
 
 ## README

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,169 +2,169 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://skills.2389.ai/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/glossary/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/css-development/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/firebase-development/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/landing-page-design/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/xtool/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/building-multiagent-systems/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/speed-run/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/test-kitchen/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/simmer/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/scenario-testing/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/fresh-eyes-review/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/documentation-audit/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/ceo-personal-os/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/worldview-synthesis/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/deliberation/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/terminal-title/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/slack-mcp/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/remote-system-maintenance/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/binary-re/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/review-squad/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/git-repo-prep/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/prbuddy/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/summarize-meetings/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/jam/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/agent-drugs/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/socialmedia/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/journal/</loc>
-    <lastmod>2026-05-28</lastmod>
+    <lastmod>2026-05-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://skills.2389.ai/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -14,157 +14,157 @@
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/css-development/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/firebase-development/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/landing-page-design/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/xtool/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/building-multiagent-systems/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/speed-run/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/test-kitchen/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/simmer/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/scenario-testing/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/fresh-eyes-review/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/documentation-audit/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/ceo-personal-os/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/worldview-synthesis/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/deliberation/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/terminal-title/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/slack-mcp/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/remote-system-maintenance/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/binary-re/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/review-squad/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/git-repo-prep/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/prbuddy/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/summarize-meetings/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/jam/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/agent-drugs/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/socialmedia/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.2389.ai/plugins/journal/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/scripts/generate-site.js
+++ b/scripts/generate-site.js
@@ -11,6 +11,10 @@ const marketplace = JSON.parse(
 );
 
 const INTERNAL_MARKETPLACE_COMMAND = '/plugin marketplace add 2389-research/claude-plugins';
+// Claude Code registers a marketplace under the top-level `name` field in marketplace.json,
+// and `/plugin install` resolves plugins as `<plugin>@<marketplace-name>`. Derive it from the
+// manifest so the generated install commands always match the registered marketplace name.
+const MARKETPLACE_NAME = marketplace.name;
 const SITE_URL = 'https://skills.2389.ai';
 const BUILD_DATE = new Date().toISOString().slice(0, 10);
 
@@ -530,7 +534,7 @@ function generatePluginCard(plugin) {
 }
 
 function getPluginInstallCommand(plugin) {
-  return `/plugin install 2389-research/${plugin.name}`;
+  return `/plugin install ${plugin.name}@${MARKETPLACE_NAME}`;
 }
 
 function getNpxInstallCommand(plugin) {
@@ -948,7 +952,7 @@ const ccGetStartedSteps = `<div class="quick-start-steps">
               <span class="step-number">2</span>
               <div class="step-content">
                 <span class="step-label">Grab what you need</span>
-                <code>/plugin install 2389-research/better-dev</code>
+                <code>/plugin install better-dev@${MARKETPLACE_NAME}</code>
               </div>
             </div>
             <div class="step">
@@ -1278,7 +1282,7 @@ Or natively in Claude Code:
 
 \`\`\`
 ${INTERNAL_MARKETPLACE_COMMAND}
-/plugin install 2389-research/<plugin>
+/plugin install <plugin>@${MARKETPLACE_NAME}
 \`\`\`
 
 ${Object.values(categories).filter(c => c.plugins.length).map(cat =>
@@ -1323,7 +1327,7 @@ Or natively in Claude Code:
 
 \`\`\`
 ${INTERNAL_MARKETPLACE_COMMAND}
-/plugin install 2389-research/<plugin-name>
+/plugin install <plugin-name>@${MARKETPLACE_NAME}
 \`\`\`
 
 (MCP servers — ${marketplace.plugins.filter((p) => p.strict === true).map((p) => p.name).join(', ')} — install via Claude Code only; they ship no skills for npx.)

--- a/scripts/generate-site.js
+++ b/scripts/generate-site.js
@@ -15,6 +15,12 @@ const INTERNAL_MARKETPLACE_COMMAND = '/plugin marketplace add 2389-research/clau
 // and `/plugin install` resolves plugins as `<plugin>@<marketplace-name>`. Derive it from the
 // manifest so the generated install commands always match the registered marketplace name.
 const MARKETPLACE_NAME = marketplace.name;
+if (typeof MARKETPLACE_NAME !== 'string' || MARKETPLACE_NAME.trim() === '') {
+  throw new Error(
+    'marketplace.json is missing a non-empty top-level "name". The generated /plugin install ' +
+    'commands resolve as <plugin>@<name>, so an empty name would emit broken docs.'
+  );
+}
 const SITE_URL = 'https://skills.2389.ai';
 const BUILD_DATE = new Date().toISOString().slice(0, 10);
 

--- a/tests/generate-site-install-template.test.js
+++ b/tests/generate-site-install-template.test.js
@@ -1,5 +1,5 @@
 // ABOUTME: Tests that the site generator produces correct install blocks for plugin pages
-// ABOUTME: Validates install command format uses 2389-research/{name} pattern
+// ABOUTME: Validates /plugin install uses the {name}@2389-research marketplace form (issue #32)
 
 const assert = require('assert');
 const fs = require('fs');
@@ -24,20 +24,26 @@ function getInstallBlock(html) {
   return match[0];
 }
 
+// The marketplace registers under the `name` field of marketplace.json, and Claude Code
+// resolves `/plugin install` as `<plugin>@<marketplace-name>`. The npx command keeps the
+// GitHub owner/repo form (2389-research/<plugin>) since that is what vercel-labs/skills expects.
+const MARKETPLACE_NAME = require('../.claude-plugin/marketplace.json').name;
+assert.strictEqual(MARKETPLACE_NAME, '2389-research', 'marketplace name should be 2389-research (issue #32)');
+
 // Skill plugins now render install tabs (npx default + /plugin secondary)
 const cssPage = readPage('css-development');
 assert.match(cssPage, /npx skills add 2389-research\/css-development/, 'expected npx command on skill plugin page');
-assert.match(cssPage, /\/plugin install 2389-research\/css-development/, 'expected /plugin install on skill plugin page');
+assert.match(cssPage, /\/plugin install css-development@2389-research/, 'expected /plugin install at-form on skill plugin page');
 
 const socialmediaInstallBlock = getInstallBlock(readPage('socialmedia'));
 assert.match(
   socialmediaInstallBlock,
-  /\/plugin install 2389-research\/socialmedia/,
-  'expected external plugin install block to use 2389-research/{name} format'
+  /\/plugin install socialmedia@2389-research/,
+  'expected external plugin install block to use the <name>@2389-research marketplace form'
 );
 
 const simmerPage = readPage('simmer');
 assert.match(simmerPage, /npx skills add 2389-research\/simmer/, 'expected npx command on simmer page');
-assert.match(simmerPage, /\/plugin install 2389-research\/simmer/, 'expected /plugin install on simmer page');
+assert.match(simmerPage, /\/plugin install simmer@2389-research/, 'expected /plugin install at-form on simmer page');
 
 console.log('generate-site install template test passed');

--- a/tests/generate-site-npx-install.test.js
+++ b/tests/generate-site-npx-install.test.js
@@ -12,13 +12,13 @@ const read = (p) => fs.readFileSync(p, 'utf8');
 // Skill plugin page: npx present, /plugin present, npx tab active by default
 const simmer = read('docs/plugins/simmer/index.html');
 assert.match(simmer, /npx skills add 2389-research\/simmer/, 'simmer page should show npx command');
-assert.match(simmer, /\/plugin install 2389-research\/simmer/, 'simmer page should still show /plugin install');
+assert.match(simmer, /\/plugin install simmer@2389-research/, 'simmer page should still show /plugin install (at-form)');
 assert.match(simmer, /class="install-tab active"[^>]*data-tab="npx-simmer"/, 'npx tab should be active by default on simmer page');
 assert.match(simmer, /class="install-tab active"[^>]*data-tab="npx-qi-simmer"/, 'quick-install should default to npx');
 
 // MCP server page: /plugin only for the hero block
 const journal = read('docs/plugins/journal/index.html');
-assert.match(journal, /\/plugin install 2389-research\/journal/, 'journal page should show /plugin install');
+assert.match(journal, /\/plugin install journal@2389-research/, 'journal page should show /plugin install (at-form)');
 assert.doesNotMatch(journal, /qi-journal/, 'journal (MCP) quick-install must not be tabbed');
 
 // Homepage: hero shows the npx pattern, default to npx


### PR DESCRIPTION
Closes #32.

Reported by @nullthoughts: on current Claude Code, `/plugin install simmer@2389-research` fails with `Marketplace "2389-research" not found`, even though `/plugin marketplace add` succeeds. Their diagnosis was correct.

### Root cause (verified against official docs)
1. Claude Code registers a marketplace under the **`name` field** of `marketplace.json`, and `/plugin install` resolves plugins as `<plugin>@<marketplace-name>`. Our name was `2389-research-marketplace`, so `simmer@2389-research` couldn't resolve.
2. Our README documented `/plugin install 2389-research/simmer` (the `owner/plugin` slash form). That form installs directly from a repo URL — it is **not** a marketplace lookup, so it was never the right command for this flow.

(The linked anthropics/claude-code#51806 is a separate cache-discovery bug — not this. The marketplace *was* discoverable in the reporter's session.)

### Fix
- Rename the marketplace `name` → **`2389-research`** so the intuitive `simmer@2389-research` resolves.
- Generate every `/plugin install` command as `<plugin>@2389-research`, **derived from the manifest** (`scripts/generate-site.js`), so docs can't drift from the registered name again.
- Update README, CLAUDE.md example, and tests; regenerate `docs/`.
- npx commands keep the GitHub `owner/repo` form (correct for vercel-labs/skills).

### Verification
- `npm test` passes (tests now assert the `<plugin>@2389-research` at-form and that the marketplace name is `2389-research`).

> Heads-up: anyone who already added the marketplace keeps the old `2389-research-marketplace` name locally until they `/plugin marketplace update` (or remove + re-add). Fresh installs get the corrected name immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/claude-plugins/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782925276&installation_id=131176874&pr_number=40&repository=2389-research%2Fclaude-plugins&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fclaude-plugins%2Fpull%2F40&signature=5a188975276dd0821430c01663d18965d27847af56cae4970f212635526ebba5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Claude Code plugin install examples from `/plugin install <namespace>/<plugin>` to the versioned `/plugin install <plugin>@<namespace>` format across docs and examples.
  * Updated plugin pages and site metadata publication dates to the new release date.

* **Chores**
  * Updated site generation and tests to produce and validate the new install command format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->