### PR TITLE
Add atelier to the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -549,7 +549,7 @@
         "source": "url",
         "url": "https://github.com/2389-research/atelier.git"
       },
-      "description": "Tiered-delegation execution - Sonnet plans a spec into sprints, a cheap Haiku agent builds and self-verifies against the gate, with a scoped Sonnet fix only on failure. Benchmarked ~64% cheaper than Opus at equal quality. Code and non-code.",
+      "description": "Tiered-delegation execution where Sonnet plans a spec into sprints, a cheap Haiku agent builds and self-verifies against the gate, and a scoped Sonnet fix runs only on failure - benchmarked ~64% cheaper than Opus at equal quality.",
       "version": "0.2.0",
       "keywords": [
         "orchestration",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -388,7 +388,7 @@
         "source": "url",
         "url": "https://github.com/2389-research/review-squad.git"
       },
-      "description": "Dispatch panels of specialized subagents to review projects — expert audits, first-impression personas, task-completion flows, and pedantic nitpicks",
+      "description": "Dispatch panels of specialized subagents to review projects \u2014 expert audits, first-impression personas, task-completion flows, and pedantic nitpicks",
       "version": "1.0.0",
       "keywords": [
         "review",
@@ -542,6 +542,24 @@
         "diary"
       ],
       "strict": true
+    },
+    {
+      "name": "atelier",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/2389-research/atelier.git"
+      },
+      "description": "Tiered-delegation execution - Sonnet plans a spec into sprints, a cheap Haiku agent builds and self-verifies against the gate, with a scoped Sonnet fix only on failure. Benchmarked ~64% cheaper than Opus at equal quality. Code and non-code.",
+      "version": "0.2.0",
+      "keywords": [
+        "orchestration",
+        "delegation",
+        "tiered-build",
+        "multi-agent",
+        "codegen",
+        "cost"
+      ],
+      "strict": false
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Or natively in Claude Code:
 | [xtool](https://github.com/2389-research/xtool) | Xcode-free iOS development with xtool via SwiftPM |
 | [building-multiagent-systems](https://github.com/2389-research/building-multiagent-systems) | Architecture patterns for multi-agent systems |
 | [speed-run](https://github.com/2389-research/speed-run) | Token-efficient code generation with hosted LLM (Cerebras) |
+| [atelier](https://github.com/2389-research/atelier) | Tiered-delegation execution: Sonnet plans a spec into sprints, cheap Haiku executes + self-verifies; ~64% cheaper than Opus |
 | [binary-re](https://github.com/2389-research/binary-re) | Agentic binary reverse engineering for ELF binaries |
 
 ### Testing and Quality


### PR DESCRIPTION
Adds [atelier](https://github.com/2389-research/atelier) — tiered-delegation task execution. Sonnet plans a spec into sprints, a cheap Haiku agent builds + self-verifies against the gate, and a scoped Sonnet fix runs only on failure. Benchmarked **~64% cheaper than Opus** at equal gate quality across 7 tasks (JS / Python / Go / prose).

## Changes
- `marketplace.json` entry → `https://github.com/2389-research/atelier.git` (public, MIT), `version: 0.2.0`, `strict: false`.
- README catalog row under **Development**.
- `docs/` intentionally left out — the `generate-site` workflow regenerates and commits it on merge to `main`.

## Verification
- `marketplace.json` parses; `npm test` passes (install-template + npx-install).
- `node scripts/generate-site.js` runs clean: "27 plugins across 4 categories", atelier page generated.

## ⚠️ Merge order
Merge **after** atelier `v0.2.0` is on its default branch (its PRs #2 + #3 add the marketplace metadata, the Sonnet-architect doc fixes, and the MIT LICENSE). Merging this first would list the repo while its `main` is still at v0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/claude-plugins/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782933588&installation_id=131176874&pr_number=41&repository=2389-research%2Fclaude-plugins&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fclaude-plugins%2Fpull%2F41&signature=6ead5d6bcb8417c6f3ce89154f44d575ba1966e3c7057460f0a8aaedf3255790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated marketplace plugin metadata for an existing plugin.
  * Added new atelier plugin (v0.2.0) to the marketplace, introducing tiered-delegation execution capabilities.

* **Documentation**
  * Updated the marketplace README to include the new atelier plugin and its workflow description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->