### PR TITLE
fix: absolutize all relative README links in generated site (#43)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "generate": "node scripts/generate-site.js && node scripts/generate-og-images.js",
     "generate:site": "node scripts/generate-site.js",
     "generate:og": "node scripts/generate-og-images.js",
-    "test": "node tests/generate-site-install-template.test.js && node tests/generate-site-npx-install.test.js"
+    "test": "node tests/convert-repo-links.test.js && node tests/generate-site-install-template.test.js && node tests/generate-site-npx-install.test.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/generate-site.js
+++ b/scripts/generate-site.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync, execFileSync } = require('child_process');
+const { convertRepoLinks } = require('./lib/convert-repo-links');
 
 // Read marketplace.json
 const marketplace = JSON.parse(
@@ -107,60 +108,9 @@ const linkReport = {
   broken: []
 };
 
-// Convert relative repo links to GitHub URLs using per-plugin repos
-function convertRepoLinks(html, pluginName, repoName) {
-  if (!html) return html;
-
-  const repo = repoName || `2389-research/${pluginName}`;
-
-  // Match <a href="..."> where href is a relative path to .md file or directory
-  // Covers: known dirs (skills/, docs/, tests/, hooks/), any root-level .md file
-  // (CLAUDE.md, README.md, ROADMAP.md, ARCHITECTURE.md, CONTRIBUTING.md, etc.),
-  // and parent-relative paths.
-  return html.replace(
-    /<a href="(\.?\.?\/?)((?:skills|docs|tests|hooks)(?:\/[^"]+)?|[^"\/]+\.md|\.\.\/?[^"]*)"([^>]*)>([^<]*)<\/a>/g,
-    (match, prefix, linkPath, attrs, linkText) => {
-      // Normalize the path
-      let normalizedPath = linkPath.replace(/^\.\//, '');
-
-      // Handle cross-plugin links (../other-plugin/) by linking to marketplace pages
-      if (normalizedPath.startsWith('../')) {
-        const crossPluginMatch = normalizedPath.match(/^\.\.\/([^/]+)\/?(.*)$/);
-        if (crossPluginMatch) {
-          const [, otherPlugin] = crossPluginMatch;
-          // Check if the other plugin exists in the marketplace
-          const otherExists = marketplace.plugins.some(p => p.name === otherPlugin);
-          if (otherExists) {
-            linkReport.converted.push({
-              plugin: pluginName,
-              from: linkPath,
-              to: `../${otherPlugin}/`
-            });
-            return `<a href="../${otherPlugin}/"${attrs}>${linkText}</a>`;
-          } else {
-            linkReport.broken.push({
-              plugin: pluginName,
-              path: linkPath,
-              reason: 'Cross-plugin target not found in marketplace'
-            });
-            return `<span class="broken-link" title="Link target not found">${linkText}</span>`;
-          }
-        }
-      }
-
-      // Determine URL type heuristically: paths with extensions are blobs, others are trees
-      const hasExtension = /\.\w+$/.test(normalizedPath);
-      const urlType = hasExtension ? 'blob' : 'tree';
-      const githubUrl = `https://github.com/${repo}/${urlType}/main/${normalizedPath}`;
-      linkReport.converted.push({
-        plugin: pluginName,
-        from: linkPath,
-        to: githubUrl
-      });
-      return `<a href="${githubUrl}"${attrs} target="_blank">${linkText}</a>`;
-    }
-  );
-}
+// convertRepoLinks lives in ./lib/convert-repo-links.js so it can be unit-tested in
+// isolation. It absolutizes relative README links against each plugin's GitHub repo;
+// marketplace.plugins and linkReport are passed in at the call site below.
 
 // Convert markdown table to HTML
 function convertMarkdownTable(tableText) {
@@ -728,7 +678,10 @@ function generatePluginPage(plugin) {
   const repo = getRepoName(plugin);
   let readmeHtml = markdownToHtml(readme);
   // Convert relative links to GitHub URLs using per-plugin repo
-  readmeHtml = convertRepoLinks(readmeHtml, plugin.name, repo);
+  readmeHtml = convertRepoLinks(readmeHtml, plugin.name, repo, {
+    marketplacePlugins: marketplace.plugins,
+    linkReport,
+  });
   const isExternal = plugin.strict === true;
 
   const tags = (plugin.keywords || []).map(k =>

--- a/scripts/lib/convert-repo-links.js
+++ b/scripts/lib/convert-repo-links.js
@@ -1,0 +1,71 @@
+// ABOUTME: Converts relative repo links in rendered README HTML to absolute GitHub URLs
+// ABOUTME: Skips absolute/anchor hrefs; routes cross-plugin links to sibling marketplace pages
+
+// Convert relative repo links to GitHub URLs using per-plugin repos.
+// Dependencies are injected so the function stays pure and unit-testable:
+//   - marketplacePlugins: array of plugin entries ({ name }) used to resolve cross-plugin links
+//   - linkReport: { converted: [], broken: [] } accumulator for build-time reporting
+function convertRepoLinks(html, pluginName, repoName, { marketplacePlugins = [], linkReport } = {}) {
+  if (!html) return html;
+
+  const repo = repoName || `2389-research/${pluginName}`;
+  const report = linkReport || { converted: [], broken: [] };
+
+  // Match every <a href="...">...</a>. The link text uses [\s\S]*? (not [^<]*) so
+  // anchors whose text contains nested tags — e.g. a backtick link rendered as
+  // <a href="..."><code>eval/RESULTS.md</code></a> — are still matched.
+  return html.replace(
+    /<a href="([^"]*)"([^>]*)>([\s\S]*?)<\/a>/g,
+    (match, href, attrs, linkText) => {
+      // Leave absolute references untouched: full URLs (http:, https:, mailto:, etc.),
+      // protocol-relative (//host), in-page anchors (#frag), and empty hrefs. Everything
+      // else is treated as a repo-relative path and absolutized below.
+      if (href === '' || /^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i.test(href)) {
+        return match;
+      }
+
+      // Normalize the path
+      let normalizedPath = href.replace(/^\.\//, '');
+
+      // Handle cross-plugin links (../other-plugin/) by linking to marketplace pages
+      if (normalizedPath.startsWith('../')) {
+        const crossPluginMatch = normalizedPath.match(/^\.\.\/([^/]+)\/?(.*)$/);
+        if (crossPluginMatch) {
+          const [, otherPlugin] = crossPluginMatch;
+          // Check if the other plugin exists in the marketplace
+          const otherExists = marketplacePlugins.some(p => p.name === otherPlugin);
+          if (otherExists) {
+            report.converted.push({
+              plugin: pluginName,
+              from: href,
+              to: `../${otherPlugin}/`
+            });
+            return `<a href="../${otherPlugin}/"${attrs}>${linkText}</a>`;
+          } else {
+            report.broken.push({
+              plugin: pluginName,
+              path: href,
+              reason: 'Cross-plugin target not found in marketplace'
+            });
+            return `<span class="broken-link" title="Link target not found">${linkText}</span>`;
+          }
+        }
+      }
+
+      // Repo-relative path: strip any leading slashes, then resolve against the plugin repo.
+      // Determine URL type heuristically: paths with extensions are blobs, others are trees.
+      normalizedPath = normalizedPath.replace(/^\/+/, '');
+      const hasExtension = /\.\w+$/.test(normalizedPath);
+      const urlType = hasExtension ? 'blob' : 'tree';
+      const githubUrl = `https://github.com/${repo}/${urlType}/main/${normalizedPath}`;
+      report.converted.push({
+        plugin: pluginName,
+        from: href,
+        to: githubUrl
+      });
+      return `<a href="${githubUrl}"${attrs} target="_blank">${linkText}</a>`;
+    }
+  );
+}
+
+module.exports = { convertRepoLinks };

--- a/tests/convert-repo-links.test.js
+++ b/tests/convert-repo-links.test.js
@@ -1,0 +1,124 @@
+// ABOUTME: Unit tests for convertRepoLinks — absolutizes relative README links (issue #43)
+// ABOUTME: Covers non-allowlisted dirs, <code> link text, cross-plugin, and untouched absolute/anchor links
+
+const assert = require('assert');
+const { convertRepoLinks } = require('../scripts/lib/convert-repo-links');
+
+const REPO = '2389-research/thrifty';
+// Fresh deps per call so linkReport bookkeeping never bleeds between cases.
+const deps = () => ({
+  marketplacePlugins: [{ name: 'thrifty' }, { name: 'simmer' }],
+  linkReport: { converted: [], broken: [] },
+});
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed++;
+}
+
+// 1. Core bug: a link into a non-allowlisted dir must be absolutized to a blob URL.
+check('non-allowlisted dir (eval/) is absolutized', () => {
+  const html = '<a href="eval/RESULTS.md" rel="noopener noreferrer">results</a>';
+  const out = convertRepoLinks(html, 'thrifty', REPO, deps());
+  assert.match(
+    out,
+    /href="https:\/\/github\.com\/2389-research\/thrifty\/blob\/main\/eval\/RESULTS\.md"/,
+    'eval/RESULTS.md should become a github.com blob URL'
+  );
+});
+
+// 2. Root cause #2: backtick link renders <code> inside the anchor text.
+check('code-formatted link text is absolutized and preserved', () => {
+  const html = '<a href="eval/RESULTS.md" rel="noopener noreferrer"><code>eval/RESULTS.md</code></a>';
+  const out = convertRepoLinks(html, 'thrifty', REPO, deps());
+  assert.match(
+    out,
+    /href="https:\/\/github\.com\/2389-research\/thrifty\/blob\/main\/eval\/RESULTS\.md"/,
+    '<code>-wrapped link should still be absolutized'
+  );
+  assert.match(out, /<code>eval\/RESULTS\.md<\/code>/, 'inner <code> text must be preserved');
+});
+
+// 3. ./-relative path into another non-allowlisted dir.
+check('./experiments/ link is absolutized', () => {
+  const html = '<a href="./experiments/README.md" rel="noopener noreferrer">exp</a>';
+  const out = convertRepoLinks(html, 'thrifty', REPO, deps());
+  assert.match(
+    out,
+    /href="https:\/\/github\.com\/2389-research\/thrifty\/blob\/main\/experiments\/README\.md"/,
+    './experiments/README.md should be absolutized (and ./ stripped)'
+  );
+});
+
+// 4. Extensionless path → tree URL (directory heuristic preserved).
+check('extensionless path uses a tree URL', () => {
+  const html = '<a href="lib" rel="noopener noreferrer">lib</a>';
+  const out = convertRepoLinks(html, 'thrifty', REPO, deps());
+  assert.match(
+    out,
+    /href="https:\/\/github\.com\/2389-research\/thrifty\/tree\/main\/lib"/,
+    'a path with no extension should resolve to a tree URL'
+  );
+});
+
+// 5-8. Absolute / protocol-relative / anchor / mailto hrefs are left untouched.
+check('https:// link is left untouched', () => {
+  const html = '<a href="https://example.com" rel="noopener noreferrer">x</a>';
+  assert.strictEqual(convertRepoLinks(html, 'thrifty', REPO, deps()), html);
+});
+check('mailto: link is left untouched', () => {
+  const html = '<a href="mailto:hello@2389.ai">mail</a>';
+  assert.strictEqual(convertRepoLinks(html, 'thrifty', REPO, deps()), html);
+});
+check('#anchor link is left untouched', () => {
+  const html = '<a href="#install">jump</a>';
+  assert.strictEqual(convertRepoLinks(html, 'thrifty', REPO, deps()), html);
+});
+check('protocol-relative //host link is left untouched', () => {
+  const html = '<a href="//cdn.example.com/x.js">cdn</a>';
+  assert.strictEqual(convertRepoLinks(html, 'thrifty', REPO, deps()), html);
+});
+
+// 9. Regression: an allowlisted dir still works.
+check('skills/ link is still absolutized', () => {
+  const html = '<a href="skills/foo/SKILL.md" rel="noopener noreferrer">skill</a>';
+  const out = convertRepoLinks(html, 'thrifty', REPO, deps());
+  assert.match(
+    out,
+    /href="https:\/\/github\.com\/2389-research\/thrifty\/blob\/main\/skills\/foo\/SKILL\.md"/,
+    'skills/ links must keep working'
+  );
+});
+
+// 10. Cross-plugin link to a known plugin → sibling marketplace page.
+check('cross-plugin link to a known plugin points at the sibling page', () => {
+  const html = '<a href="../simmer/" rel="noopener noreferrer">simmer</a>';
+  const out = convertRepoLinks(html, 'thrifty', REPO, deps());
+  assert.match(out, /href="\.\.\/simmer\/"/, 'known cross-plugin link should stay a relative sibling link');
+  assert.doesNotMatch(out, /github\.com/, 'cross-plugin link must not be turned into a github URL');
+});
+
+// 11. Cross-plugin link to an unknown plugin → broken-link span.
+check('cross-plugin link to an unknown plugin renders a broken-link span', () => {
+  const html = '<a href="../nope/" rel="noopener noreferrer">nope</a>';
+  const out = convertRepoLinks(html, 'thrifty', REPO, deps());
+  assert.match(out, /<span class="broken-link"/, 'unknown cross-plugin target should render a broken-link span');
+});
+
+// 12. linkReport bookkeeping records the conversion.
+check('linkReport records converted links', () => {
+  const linkReport = { converted: [], broken: [] };
+  convertRepoLinks('<a href="eval/RESULTS.md">r</a>', 'thrifty', REPO, { marketplacePlugins: [], linkReport });
+  assert.strictEqual(linkReport.converted.length, 1, 'a converted link should be recorded in linkReport.converted');
+});
+
+// 13. Multiple links on one line are converted independently (non-greedy text match).
+check('multiple anchors on one line are each handled', () => {
+  const html = '<a href="eval/A.md">a</a> and <a href="https://x.com">b</a>';
+  const out = convertRepoLinks(html, 'thrifty', REPO, deps());
+  assert.match(out, /blob\/main\/eval\/A\.md/, 'first (relative) link should be absolutized');
+  assert.match(out, /href="https:\/\/x\.com"/, 'second (absolute) link should be left untouched');
+});
+
+console.log(`convert-repo-links test passed (${passed} cases)`);


### PR DESCRIPTION
Fixes #43.

## Problem

`scripts/generate-site.js` → `convertRepoLinks()` left some relative repo links un-absolutized when rendering a plugin's README onto the site, shipping them as broken relative links (404 against the live site). Two root causes, both identified by @sugi-chan:

1. **Dir allowlist too narrow.** The match only covered `skills|docs|tests|hooks`, root-level `*.md`, and `../` paths. A link into any other dir (`eval/RESULTS.md`, `experiments/README.md`, `src/…`) never matched → never absolutized.
2. **Link text with nested tags skipped.** The text group `([^<]*)` stopped at the first `<`, so a backtick link rendered as `<a href="…"><code>eval/RESULTS.md</code></a>` was missed even in an allowlisted dir.

## Fix

Generalize the matcher to **every** `<a href="…">…</a>` (link text via `[\s\S]*?` so nested tags are allowed), then **skip only absolute hrefs** — full URLs (`http:`/`https:`/`mailto:`/…), protocol-relative (`//host`), in-page anchors (`#frag`), and empty hrefs — and absolutize everything else as a repo-relative path. Existing cross-plugin (`../other-plugin/`) handling and `linkReport` bookkeeping are preserved.

The function is extracted into `scripts/lib/convert-repo-links.js` with its two dependencies injected (`marketplacePlugins`, `linkReport`) so it can be unit-tested in isolation without running the whole generator.

## Verification

- **New unit test** `tests/convert-repo-links.test.js` (13 cases), added to `npm test`. Written against the *old* logic first to confirm it reproduced the bug (red), then green after the fix.
- **Full `npm test` passes** (all three suites).
- **End-to-end:** regenerated the site and scanned all 27 plugin pages — **0 leftover relative README links**; generator reports **54 links converted, 0 broken**.

Real before/after on the thrifty page (the page from the issue):

```diff
-<a href="eval/RESULTS.md" rel="noopener noreferrer">benchmarked</a>
+<a href="https://github.com/2389-research/thrifty/blob/main/eval/RESULTS.md" rel="noopener noreferrer">benchmarked</a>

-<a href="eval/RESULTS.md" rel="noopener noreferrer"><code>eval/RESULTS.md</code></a>
+<a href="https://github.com/2389-research/thrifty/blob/main/eval/RESULTS.md" rel="noopener noreferrer"><code>eval/RESULTS.md</code></a>
```

`#anchor` links stay untouched, confirming the absolute/anchor exclusions.

## Acceptance criteria

- [x] A README link into a non-allowlisted dir (`eval/RESULTS.md`) renders as `github.com/<repo>/blob/main/eval/RESULTS.md`.
- [x] A backtick link (`<code>` text) is absolutized too.
- [x] Absolute URLs, `mailto:`, and `#anchors` are left untouched.
- [x] `npm test` still passes.

## Note on `docs/`

This PR is source-only. Regenerating the site today rewrites `dateModified` on every page (date churn), and the `generate-site.yml` workflow already regenerates + commits `docs/` on push to `main` — matching the existing "chore: update marketplace site" commits. The live site picks up the fix automatically on merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/claude-plugins/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783788378&installation_id=131176874&pr_number=44&repository=2389-research%2Fclaude-plugins&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fclaude-plugins%2Fpull%2F44&signature=01a0b3e61c7a74a4172e9c0cee06ba0b29669c2271d9c1ddf325503a2f73e21d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating repository link conversion, including GitHub URL generation, cross-plugin linking, and broken link detection across various link formats.

* **Refactor**
  * Modularized link conversion functionality into a standalone, independently testable component for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->