### PR TITLE
feat: per-skill star buttons linking to each plugin's repo

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -565,6 +565,39 @@ body {
   border: 1px solid var(--border-on-card);
 }
 
+/* Per-skill star button: links to the skill's own GitHub repo, not the marketplace */
+.plugin-card-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-shrink: 0;
+}
+
+.plugin-star {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--text-on-card-secondary);
+  background: #f0f0f5;
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-on-card);
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.plugin-star:hover {
+  color: var(--accent-gold);
+  background: var(--accent-gold-dim);
+  border-color: var(--accent-gold);
+}
+
+.star-count {
+  font-variant-numeric: tabular-nums;
+}
+
 .plugin-description {
   font-size: 0.875rem;
   color: var(--text-on-card-secondary);
@@ -1259,6 +1292,30 @@ body {
   max-width: 680px;
 }
 
+/* Hero variant of the per-skill star button: outline secondary beside View Source */
+.star-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-body);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: transparent;
+  padding: 0.75rem 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.star-button:hover {
+  color: var(--accent-gold);
+  border-color: var(--accent-gold);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px var(--accent-gold-glow);
+}
+
 /* README Content Styling */
 .readme-section {
   background: var(--bg-surface);
@@ -1515,7 +1572,8 @@ body {
     max-width: none;
   }
 
-  .plugin-hero-actions .cta-button {
+  .plugin-hero-actions .cta-button,
+  .plugin-hero-actions .star-button {
     width: 100%;
     justify-content: center;
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "generate": "node scripts/generate-site.js && node scripts/generate-og-images.js",
     "generate:site": "node scripts/generate-site.js",
     "generate:og": "node scripts/generate-og-images.js",
-    "test": "node tests/generate-site-install-template.test.js && node tests/generate-site-npx-install.test.js"
+    "test": "node tests/star-button.test.js && node tests/generate-site-install-template.test.js && node tests/generate-site-npx-install.test.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/generate-site.js
+++ b/scripts/generate-site.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync, execFileSync } = require('child_process');
+const { renderStarButton } = require('./lib/star-button');
 
 // Read marketplace.json
 const marketplace = JSON.parse(
@@ -96,6 +97,22 @@ function getReadmeContent(plugin) {
       { encoding: 'utf8', timeout: 15000 }
     );
     return content || null;
+  } catch {
+    return null;
+  }
+}
+
+// Fetch the GitHub star count for a plugin's repo. Returns null on any failure
+// so the button degrades to icon-only rather than breaking the build.
+function getStarCount(plugin) {
+  const repo = getRepoName(plugin);
+  try {
+    const out = execSync(
+      `gh api repos/${repo} --jq .stargazers_count`,
+      { encoding: 'utf8', timeout: 15000 }
+    ).trim();
+    const count = parseInt(out, 10);
+    return Number.isNaN(count) ? null : count;
   } catch {
     return null;
   }
@@ -522,7 +539,10 @@ function generatePluginCard(plugin) {
                 <a href="plugins/${plugin.name}/" class="plugin-name-link" data-tinylytics-event="plugin.view-details" data-tinylytics-event-value="${plugin.name}">
                   <h4 class="plugin-name">${plugin.name}</h4>
                 </a>
-                <span class="plugin-version">v${plugin.version || '1.0.0'}</span>
+                <div class="plugin-card-meta">
+                  ${renderStarButton({ repoUrl: sourceUrl, pluginName: plugin.name, count: starCounts[plugin.name], variant: 'card' })}
+                  <span class="plugin-version">v${plugin.version || '1.0.0'}</span>
+                </div>
               </div>
               <p class="plugin-description">${description}</p>
               <div class="plugin-tags">${tags}</div>
@@ -699,7 +719,10 @@ ${related.map(p => {
             <a href="../${p.name}/" class="plugin-name-link" data-tinylytics-event="related.view-plugin" data-tinylytics-event-value="${p.name}">
               <h4 class="plugin-name">${p.name}</h4>
             </a>
-            <span class="plugin-version">v${p.version || '1.0.0'}</span>
+            <div class="plugin-card-meta">
+              ${renderStarButton({ repoUrl: getSourceUrl(p), pluginName: p.name, count: starCounts[p.name], variant: 'card' })}
+              <span class="plugin-version">v${p.version || '1.0.0'}</span>
+            </div>
           </div>
           <p class="plugin-description">${desc}</p>
           <div class="plugin-tags">${tags}</div>
@@ -804,6 +827,7 @@ ${generateHead(pluginTitle, description, `plugins/${plugin.name}/`, plugin.keywo
               })
             : `<code class="install-command" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="${plugin.name}">${getPluginInstallCommand(plugin)}</code>`}
         </div>
+        ${renderStarButton({ repoUrl: sourceUrl, pluginName: plugin.name, count: starCounts[plugin.name], variant: 'hero' })}
         <a href="${sourceUrl}" class="cta-button" rel="noopener noreferrer" target="_blank" data-tinylytics-event="plugin.view-source" data-tinylytics-event-value="${plugin.name}">
           View Source
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
@@ -919,6 +943,14 @@ const mcpServers = marketplace.plugins.filter(p =>
   p.source?.url?.includes('mcp') ||
   p.description?.toLowerCase().includes('mcp server')
 ).length || 3;
+
+// Fetch GitHub star counts once per plugin, keyed by name. Cards, related cards, and
+// plugin heroes all read from this map. Refreshed each time CI regenerates the site.
+const starCounts = {};
+marketplace.plugins.forEach(plugin => {
+  starCounts[plugin.name] = getStarCount(plugin);
+});
+console.log(`Fetched star counts for ${Object.keys(starCounts).length} plugins`);
 
 // Step list HTML for the homepage "Get Started in 30 Seconds" install tabs.
 // Extracted so the renderInstallTabs call stays readable.

--- a/scripts/lib/star-button.js
+++ b/scripts/lib/star-button.js
@@ -1,0 +1,39 @@
+// ABOUTME: Renders a per-skill "Star on GitHub" button linking to the skill's own repo
+// ABOUTME: GitHub disallows one-click starring, so this deep-links to where the user stars
+
+// GitHub's own star icon path, reused from the global nav star button.
+const STAR_SVG =
+  '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">' +
+  '<path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/>' +
+  '</svg>';
+
+// Abbreviate a star count the way GitHub does: exact below 1k, one decimal in the
+// thousands, whole thousands past 10k, and the same shape for millions. Returns null
+// for a missing count so the caller can fall back to an icon-only button.
+function formatStarCount(n) {
+  if (n === null || n === undefined || Number.isNaN(n)) return null;
+  if (n < 1000) return String(n);
+  if (n < 10000) return `${Math.floor(n / 100) / 10}k`;
+  if (n < 1000000) return `${Math.floor(n / 1000)}k`;
+  if (n < 10000000) return `${Math.floor(n / 100000) / 10}M`;
+  return `${Math.floor(n / 1000000)}M`;
+}
+
+// Build the star button anchor. variant 'card' is the compact pill used on grid cards;
+// 'hero' is the larger button on plugin pages. The href is the skill's repo, so clicking
+// lands on GitHub's native Star control for that project.
+function renderStarButton({ repoUrl, pluginName, count = null, variant = 'card' }) {
+  const cls = variant === 'hero' ? 'star-button' : 'plugin-star';
+  const formatted = formatStarCount(count);
+  const countHtml =
+    formatted !== null ? `<span class="star-count">${formatted}</span>` : '';
+  const label = `Star ${pluginName} on GitHub`;
+  return (
+    `<a href="${repoUrl}" class="${cls}" rel="noopener noreferrer" target="_blank" ` +
+    `title="${label}" aria-label="${label}" ` +
+    `data-tinylytics-event="plugin.star" data-tinylytics-event-value="${pluginName}">` +
+    `${STAR_SVG}${countHtml}</a>`
+  );
+}
+
+module.exports = { formatStarCount, renderStarButton };

--- a/tests/star-button.test.js
+++ b/tests/star-button.test.js
@@ -1,0 +1,76 @@
+// ABOUTME: Unit tests for the per-skill star button (formatStarCount + renderStarButton)
+// ABOUTME: Verifies the button links to the skill's OWN repo, not the marketplace repo
+
+const assert = require('assert');
+const { formatStarCount, renderStarButton } = require('../scripts/lib/star-button');
+
+let passed = 0;
+function check(name, fn) {
+  fn();
+  passed++;
+}
+
+// --- formatStarCount: GitHub-style abbreviations ---
+check('zero stays "0"', () => assert.strictEqual(formatStarCount(0), '0'));
+check('small ints are exact', () => assert.strictEqual(formatStarCount(42), '42'));
+check('999 stays exact', () => assert.strictEqual(formatStarCount(999), '999'));
+check('1000 -> 1k', () => assert.strictEqual(formatStarCount(1000), '1k'));
+check('1200 -> 1.2k', () => assert.strictEqual(formatStarCount(1200), '1.2k'));
+check('1234 truncates to 1.2k', () => assert.strictEqual(formatStarCount(1234), '1.2k'));
+check('10000 -> 10k (no decimal)', () => assert.strictEqual(formatStarCount(10000), '10k'));
+check('12345 -> 12k', () => assert.strictEqual(formatStarCount(12345), '12k'));
+check('1.5M', () => assert.strictEqual(formatStarCount(1500000), '1.5M'));
+check('null count -> null', () => assert.strictEqual(formatStarCount(null), null));
+check('undefined count -> null', () => assert.strictEqual(formatStarCount(undefined), null));
+
+// --- renderStarButton: card variant with a count ---
+const card = renderStarButton({
+  repoUrl: 'https://github.com/2389-research/css-development',
+  pluginName: 'css-development',
+  count: 42,
+  variant: 'card',
+});
+check('card links to the skill repo', () =>
+  assert.match(card, /href="https:\/\/github\.com\/2389-research\/css-development"/));
+check('card never points at the marketplace repo', () =>
+  assert.doesNotMatch(card, /claude-plugins/));
+check('card opens in a new tab', () => assert.match(card, /target="_blank"/));
+check('card is rel-safe', () => assert.match(card, /rel="noopener noreferrer"/));
+check('card uses the card class', () => assert.match(card, /class="plugin-star"/));
+check('card shows the formatted count', () =>
+  assert.match(card, /<span class="star-count">42<\/span>/));
+check('card has an accessible title', () =>
+  assert.match(card, /title="Star css-development on GitHub"/));
+check('card carries the tinylytics event', () =>
+  assert.match(card, /data-tinylytics-event="plugin\.star"/));
+check('card tags the event with the plugin name', () =>
+  assert.match(card, /data-tinylytics-event-value="css-development"/));
+check('card renders the star icon', () => assert.match(card, /<svg/));
+
+// --- renderStarButton: hero variant abbreviates large counts ---
+const hero = renderStarButton({
+  repoUrl: 'https://github.com/2389-research/simmer',
+  pluginName: 'simmer',
+  count: 1200,
+  variant: 'hero',
+});
+check('hero uses the hero class', () => assert.match(hero, /class="star-button"/));
+check('hero shows the abbreviated count', () =>
+  assert.match(hero, /<span class="star-count">1\.2k<\/span>/));
+check('hero links to the skill repo', () =>
+  assert.match(hero, /href="https:\/\/github\.com\/2389-research\/simmer"/));
+
+// --- renderStarButton: null count degrades to an icon-only button ---
+const noCount = renderStarButton({
+  repoUrl: 'https://github.com/2389-research/xtool',
+  pluginName: 'xtool',
+  count: null,
+  variant: 'card',
+});
+check('icon-only still links to the skill repo', () =>
+  assert.match(noCount, /href="https:\/\/github\.com\/2389-research\/xtool"/));
+check('icon-only omits the count span', () =>
+  assert.doesNotMatch(noCount, /star-count/));
+check('icon-only still renders the star icon', () => assert.match(noCount, /<svg/));
+
+console.log(`star-button test passed (${passed} cases)`);


### PR DESCRIPTION
## What

Adds a **star button to every skill** that deep-links to that plugin's **own GitHub repo** — so a user can star the individual skill, not just the marketplace `claude-plugins` repo.

Stars appear in all three places a skill card shows:
- **Homepage grid cards** (compact pill next to the version)
- **Plugin page hero** (outline-secondary button beside *View Source*)
- **Related-plugin cards** on plugin pages

Each button shows a **live star count** fetched from GitHub at build time, formatted GitHub-style (`1.2k`, `12k`, `1.5M`).

## Why a deep-link (not one-click star)

GitHub's CSRF protection means **no URL can one-click-star a repo**. The button links to the skill's repo, where the user clicks GitHub's native Star control.

## How

| File | Change |
|------|--------|
| `scripts/lib/star-button.js` *(new)* | Pure `renderStarButton` + `formatStarCount`, unit-testable in isolation |
| `scripts/generate-site.js` | `getStarCount` via `gh api repos/<repo> --jq .stargazers_count`; star-count map built once per build; wired into card / hero / related call sites |
| `docs/style.css` | `.plugin-star` card pill + `.star-button` hero variant, gold hover, mobile full-width |
| `tests/star-button.test.js` *(new)* | 27 cases — skill-repo target, count formatting, `null → icon-only` fallback |
| `package.json` | Unit test added to `npm test` |

## Resilience

If a star fetch fails (rate limit, network), `getStarCount` returns `null` and the button degrades to **icon-only** — the build never breaks.

## Verification

- `npm test` → all 3 suites green (`star-button test passed (27 cases)` + both generator tests)
- Regenerated locally: 27 cards each get a star, **0** link to `claude-plugins`, live counts render (0–13)

## Notes

Source-only PR — generated `docs/*.html` are left for CI to rebuild on merge, per repo convention. `docs/style.css` is hand-maintained source, so it's included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/claude-plugins/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783802270&installation_id=131176874&pr_number=45&repository=2389-research%2Fclaude-plugins&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fclaude-plugins%2Fpull%2F45&signature=32833df08884cd4cff52bda9d8e0b260e54d8e910a4477cdb5ee7dea7df1d483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub star count display on plugin cards and hero sections with formatted abbreviations (e.g., 1.2K, 1.5M)
  * Added "Star on GitHub" buttons throughout plugin listings linking to each repository
  * Enhanced responsive design for mobile viewing of new star UI elements

* **Tests**
  * Added comprehensive unit tests for star counting and display functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->