### PR TITLE
fix: fold - and _ in search so "review squad" matches review-squad

### DIFF
--- a/docs/glossary/index.html
+++ b/docs/glossary/index.html
@@ -112,7 +112,7 @@
   "name": "Marketplace Glossary",
   "url": "https://skills.2389.ai/glossary/",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21",
+  "dateModified": "2026-08-11",
   "hasDefinedTerm": [
     {
       "@type": "DefinedTerm",
@@ -171,13 +171,14 @@
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/index.html
+++ b/docs/index.html
@@ -651,7 +651,7 @@
     "softwareVersion": "1.0.0",
     "license": "https://opensource.org/licenses/MIT",
     "datePublished": "2026-07-20",
-    "dateModified": "2026-07-21"
+    "dateModified": "2026-08-11"
   }
   </script>
 
@@ -871,13 +871,14 @@
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/agent-drugs/index.html
+++ b/docs/plugins/agent-drugs/index.html
@@ -224,7 +224,7 @@ npm run dev:http
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -275,13 +275,14 @@ npm run dev:http
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/binary-re/index.html
+++ b/docs/plugins/binary-re/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install binary-re@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="binary-re">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/binary-re" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="binary-re">★ Star on GitHub <span class="star-count">· 11</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/binary-re" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="binary-re">★ Star on GitHub <span class="star-count">· 14</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Binary Reverse Engineering Plugin</h2>
@@ -195,7 +195,7 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -246,13 +246,14 @@ sudo apt install libc6-armhf-cross libc6-arm64-cross
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/building-multiagent-systems/index.html
+++ b/docs/plugins/building-multiagent-systems/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install building-multiagent-systems@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="building-multiagent-systems">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/building-multiagent-systems" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="building-multiagent-systems">★ Star on GitHub <span class="star-count">· 4</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/building-multiagent-systems" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="building-multiagent-systems">★ Star on GitHub <span class="star-count">· 5</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Building multi-agent systems</h2>
@@ -194,7 +194,7 @@ async function cleanup() {
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -245,13 +245,14 @@ async function cleanup() {
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/ceo-personal-os/index.html
+++ b/docs/plugins/ceo-personal-os/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install ceo-personal-os@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="ceo-personal-os">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/ceo-personal-os" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="ceo-personal-os">★ Star on GitHub <span class="star-count">· 2</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/ceo-personal-os" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="ceo-personal-os">★ Star on GitHub <span class="star-count">· 4</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>CEO Personal OS Plugin</h2>
@@ -164,7 +164,7 @@
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -215,13 +215,14 @@
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/css-development/index.html
+++ b/docs/plugins/css-development/index.html
@@ -161,7 +161,7 @@
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -212,13 +212,14 @@
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/deliberation/index.html
+++ b/docs/plugins/deliberation/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install deliberation@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="deliberation">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/deliberation" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="deliberation">★ Star on GitHub <span class="star-count">· 2</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/deliberation" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="deliberation">★ Star on GitHub <span class="star-count">· 4</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Deliberation</h2>
@@ -176,7 +176,7 @@ Business Strategist, Developer Culture voice. Anyone to add?"
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -227,13 +227,14 @@ Business Strategist, Developer Culture voice. Anyone to add?"
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/documentation-audit/index.html
+++ b/docs/plugins/documentation-audit/index.html
@@ -139,7 +139,7 @@
   "softwareVersion": "2.0.1",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -190,13 +190,14 @@
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/firebase-development/index.html
+++ b/docs/plugins/firebase-development/index.html
@@ -159,7 +159,7 @@ export const users = {
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -210,13 +210,14 @@ export const users = {
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/fresh-eyes-review/index.html
+++ b/docs/plugins/fresh-eyes-review/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install fresh-eyes-review@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="fresh-eyes-review">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/fresh-eyes-review" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="fresh-eyes-review">★ Star on GitHub <span class="star-count">· 2</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/fresh-eyes-review" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="fresh-eyes-review">★ Star on GitHub <span class="star-count">· 3</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Fresh-eyes review</h2>
@@ -165,7 +165,7 @@
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -216,13 +216,14 @@
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/git-repo-prep/index.html
+++ b/docs/plugins/git-repo-prep/index.html
@@ -161,7 +161,7 @@
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -212,13 +212,14 @@
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/jam/index.html
+++ b/docs/plugins/jam/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install jam@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="jam">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/jam" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="jam">★ Star on GitHub <span class="star-count">· 0</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/jam" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="jam">★ Star on GitHub <span class="star-count">· 1</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Jam</h2>
@@ -201,7 +201,7 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -252,13 +252,14 @@ evals/                       Comparative eval harness (Jam vs. other approaches)
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/journal/index.html
+++ b/docs/plugins/journal/index.html
@@ -312,7 +312,7 @@ Vector embeddings provide semantic understanding...
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -363,13 +363,14 @@ Vector embeddings provide semantic understanding...
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/landing-page-design/index.html
+++ b/docs/plugins/landing-page-design/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install landing-page-design@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="landing-page-design">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/landing-page-design" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="landing-page-design">★ Star on GitHub <span class="star-count">· 8</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/landing-page-design" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="landing-page-design">★ Star on GitHub <span class="star-count">· 14</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Landing Page Design Plugin</h2>
@@ -180,7 +180,7 @@ Full animation system for entrances, continuous effects, interactions, and decor
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -231,13 +231,14 @@ Full animation system for entrances, continuous effects, interactions, and decor
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/prbuddy/index.html
+++ b/docs/plugins/prbuddy/index.html
@@ -139,7 +139,7 @@
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -190,13 +190,14 @@
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/remote-system-maintenance/index.html
+++ b/docs/plugins/remote-system-maintenance/index.html
@@ -208,7 +208,7 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -259,13 +259,14 @@ snap remove &lt;package-name&gt; --revision=&lt;revision-number&gt;
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/review-squad/index.html
+++ b/docs/plugins/review-squad/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install review-squad@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="review-squad">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/review-squad" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="review-squad">★ Star on GitHub <span class="star-count">· 6</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/review-squad" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="review-squad">★ Star on GitHub <span class="star-count">· 8</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Review Squad</h2>
@@ -185,7 +185,7 @@ things professional reviewers skip because they're too polite.
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -236,13 +236,14 @@ things professional reviewers skip because they're too polite.
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/scenario-testing/index.html
+++ b/docs/plugins/scenario-testing/index.html
@@ -209,7 +209,7 @@ def test_user_registration_scenario():
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -260,13 +260,14 @@ def test_user_registration_scenario():
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/simmer/index.html
+++ b/docs/plugins/simmer/index.html
@@ -243,7 +243,7 @@ docs/simmer/                   # Tracking files (separate from workspace)
   "softwareVersion": "3.0.1",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -294,13 +294,14 @@ docs/simmer/                   # Tracking files (separate from workspace)
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/slack-mcp/index.html
+++ b/docs/plugins/slack-mcp/index.html
@@ -226,7 +226,7 @@ npm start
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -277,13 +277,14 @@ npm start
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/socialmedia/index.html
+++ b/docs/plugins/socialmedia/index.html
@@ -74,7 +74,7 @@
           <code class="mono">/plugin install socialmedia@2389-research</code>
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install socialmedia@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="socialmedia">Copy</button>
         </div>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/mcp-socialmedia" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="socialmedia">★ Star on GitHub <span class="star-count">· 13</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/mcp-socialmedia" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="socialmedia">★ Star on GitHub <span class="star-count">· 14</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>🚀 MCP Agent Social Media Server</h2>
@@ -211,7 +211,7 @@ docker-compose up -d
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -262,13 +262,14 @@ docker-compose up -d
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/speed-run/index.html
+++ b/docs/plugins/speed-run/index.html
@@ -221,7 +221,7 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
   "softwareVersion": "1.1.1",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -272,13 +272,14 @@ The most direct comparison: test-kitchen's <strong>cookoff</strong> vs speed-run
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/summarize-meetings/index.html
+++ b/docs/plugins/summarize-meetings/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install summarize-meetings@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="summarize-meetings">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/summarize-meetings" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="summarize-meetings">★ Star on GitHub <span class="star-count">· 11</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/summarize-meetings" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="summarize-meetings">★ Star on GitHub <span class="star-count">· 12</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Summarize Meetings</h2>
@@ -153,7 +153,7 @@
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -204,13 +204,14 @@
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/terminal-title/index.html
+++ b/docs/plugins/terminal-title/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install terminal-title@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="terminal-title">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/terminal-title" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="terminal-title">★ Star on GitHub <span class="star-count">· 1</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/terminal-title" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="terminal-title">★ Star on GitHub <span class="star-count">· 2</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Terminal title</h2>
@@ -182,7 +182,7 @@ export TERMINAL_TITLE_EMOJI=💼
   "softwareVersion": "1.1.2",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -233,13 +233,14 @@ export TERMINAL_TITLE_EMOJI=💼
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/test-kitchen/index.html
+++ b/docs/plugins/test-kitchen/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install test-kitchen@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="test-kitchen">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/test-kitchen" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="test-kitchen">★ Star on GitHub <span class="star-count">· 3</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/test-kitchen" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="test-kitchen">★ Star on GitHub <span class="star-count">· 4</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Test Kitchen</h2>
@@ -231,7 +231,7 @@ Which approach?
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -282,13 +282,14 @@ Which approach?
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/thrifty/index.html
+++ b/docs/plugins/thrifty/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install thrifty@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="thrifty">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/thrifty" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="thrifty">★ Star on GitHub <span class="star-count">· 7</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/thrifty" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="thrifty">★ Star on GitHub <span class="star-count">· 15</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>thrifty</h2>
@@ -231,7 +231,7 @@ it costs materially more (see why below).</blockquote>
   "softwareVersion": "0.5.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -282,13 +282,14 @@ it costs materially more (see why below).</blockquote>
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/worldview-synthesis/index.html
+++ b/docs/plugins/worldview-synthesis/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="btn-ghost-sm mono" data-copy="/plugin install worldview-synthesis@2389-research" data-tinylytics-event="plugin.copy-install" data-tinylytics-event-value="worldview-synthesis">Copy</button>
         </div>
         </details>
-      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/worldview-synthesis" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="worldview-synthesis">★ Star on GitHub <span class="star-count">· 4</span></a></div>
+      <div class="detail-actions"><a class="detail-star btn-ghost-sm mono" href="https://github.com/2389-research/worldview-synthesis" target="_blank" rel="noopener noreferrer" data-tinylytics-event="plugin.star-github" data-tinylytics-event-value="worldview-synthesis">★ Star on GitHub <span class="star-count">· 5</span></a></div>
     </header>
     <main id="main-content" class="readme-body">
       <h2>Worldview Synthesis Plugin</h2>
@@ -175,7 +175,7 @@ Find the cracks. Leave no trace.
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -226,13 +226,14 @@ Find the cracks. Leave no trace.
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/plugins/xtool/index.html
+++ b/docs/plugins/xtool/index.html
@@ -162,7 +162,7 @@ xtool dev
   "softwareVersion": "1.0.0",
   "license": "https://opensource.org/licenses/MIT",
   "datePublished": "2026-07-20",
-  "dateModified": "2026-07-21"
+  "dateModified": "2026-08-11"
 }
   </script>
 
@@ -213,13 +213,14 @@ xtool dev
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,7 +8,7 @@
   </url>
   <url>
     <loc>https://skills.2389.ai/glossary/</loc>
-    <lastmod>2026-07-21</lastmod>
+    <lastmod>2026-08-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/scripts/generate-site.js
+++ b/scripts/generate-site.js
@@ -524,6 +524,8 @@ function pluginHasSkills(plugin) {
 
 // Shared interactive <script>: copy-to-clipboard, search/filter, topo background.
 // Used by both the homepage and every plugin page.
+// NB: the body is a template literal — a regex escape like \s loses its backslash on the way
+// out, so emitted regexes must use explicit character classes ([-_ ], not \s).
 function generateInteractiveScript() {
   return `<script>
   document.querySelectorAll('[data-copy]').forEach(btn => {
@@ -544,13 +546,14 @@ function generateInteractiveScript() {
     const chips = [...document.querySelectorAll('.chip[data-cat]')];
     const clearTag = document.querySelector('[data-cleartag]');
     let cat = 'all', tag = null;
+    const norm = s => s.toLowerCase().replace(/[-_ ]+/g, ' ');
     const apply = () => {
-      const q = search.value.trim().toLowerCase();
+      const q = norm(search.value.trim());
       let shown = 0;
       rows.forEach(r => {
         const okCat = cat === 'all' || r.dataset.cat === cat;
         const okTag = !tag || (r.dataset.tags || '').split(',').includes(tag);
-        const hay = (r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags).toLowerCase();
+        const hay = norm(r.dataset.name + ' ' + r.dataset.desc + ' ' + r.dataset.tags);
         const okQ = !q || hay.includes(q);
         const show = okCat && okTag && okQ;
         r.style.display = show ? '' : 'none';

--- a/tests/generate-site-redesign.test.js
+++ b/tests/generate-site-redesign.test.js
@@ -58,6 +58,19 @@ test('script: filter wiring reads skill rows on input', () => {
   assert.match(index, /\[data-skill-row\]/);
   assert.match(index, /addEventListener\('input'/);
 });
+test('search: norm() folds separators so "review squad" finds review-squad', () => {
+  // The shipped script defines a one-line normalizer we can extract and execute.
+  const m = index.match(/const norm = (.*?);/);
+  assert.ok(m, 'interactive script defines a norm() helper');
+  const norm = eval('(' + m[1] + ')');
+  // Users type names as spoken; entries are kebab_or_snake case. Both sides fold to the same form.
+  assert.strictEqual(norm('review squad'), norm('review-squad'));
+  assert.strictEqual(norm('Fresh Eyes Review'), norm('fresh-eyes-review'));
+  assert.strictEqual(norm('slack mcp'), norm('slack_mcp'));
+  // Both the query and the haystack go through norm(), so hyphenated queries keep working too.
+  assert.match(index, /norm\(search\.value/);
+  assert.match(index, /hay = norm\(/);
+});
 test('index: one row per marketplace entry, with details links', () => {
   const marketplace = JSON.parse(fs.readFileSync(path.join(ROOT, '.claude-plugin/marketplace.json'), 'utf8'));
   const rowCount = (index.match(/class="skill-row"/g) || []).length;


### PR DESCRIPTION
The library search was a literal substring match, so a query like "review squad" never found review-squad — but spoken-form is how people type the names.

## Fix
The interactive script now ships a one-line normalizer applied to both the query and the haystack:

```js
const norm = s => s.toLowerCase().replace(/[-_ ]+/g, " ");
```

"review squad", "Fresh Eyes Review", and "slack mcp" now match their kebab/snake-case entries; hyphenated queries keep working. Chip/tag exact-match filtering is untouched.

The character class is `[-_ ]` rather than `\s` on purpose: the script is emitted from a template literal, where `\s` would silently drop its backslash. A comment above `generateInteractiveScript` now warns about that trap.

## Test
New behavioral test extracts the shipped `norm()` from the generated `docs/index.html` and executes it (written first, watched fail). Suite is 26/26.

Everything else in the diff is regenerated site output (script + routine lastmod/date bumps).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/claude-plugins/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789056542&installation_model_id=21126&pr_number=49&repository=2389-research%2Fclaude-plugins&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Fclaude-plugins%2Fpull%2F49&signature=d68765d42800b1cf1e2745f324b5e1bd6be0dc7005a163aa2e5e1919df1d494e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now matches terms consistently regardless of spaces, hyphens, or underscores.
  * Updated displayed repository star counts across several plugin pages.
* **Documentation**
  * Refreshed catalog and plugin metadata dates.
  * Updated the glossary sitemap date.
* **Tests**
  * Added coverage confirming separator-insensitive search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->